### PR TITLE
unicode names now work. Special characters in names will get that org skipped. With tests.

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,7 +16,6 @@ from dictalchemy import make_class_dictable
 from dateutil.tz import tzoffset
 from mimetypes import guess_type
 from copy import deepcopy
-from urllib import quote
 from os.path import join
 from math import ceil
 
@@ -139,41 +138,41 @@ class Organization(db.Model):
         ''' API link to all an orgs events
         '''
         # Make a nice org name
-        organization_name = quote(safe_name(self.name).encode('utf8'))
+        organization_name = safe_name(self.name)
         return '%s://%s/api/organizations/%s/events' % (request.scheme, request.host, organization_name)
 
     def upcoming_events(self):
         ''' API link to an orgs upcoming events
         '''
         # Make a nice org name
-        organization_name = quote(safe_name(self.name).encode('utf8'))
+        organization_name = safe_name(self.name)
         return '%s://%s/api/organizations/%s/upcoming_events' % (request.scheme, request.host, organization_name)
 
     def past_events(self):
         ''' API link to an orgs past events
         '''
         # Make a nice org name
-        organization_name = quote(safe_name(self.name).encode('utf8'))
+        organization_name = safe_name(self.name)
         return '%s://%s/api/organizations/%s/past_events' % (request.scheme, request.host, organization_name)
 
     def all_projects(self):
         ''' API link to all an orgs projects
         '''
         # Make a nice org name
-        organization_name = quote(safe_name(self.name).encode('utf8'))
+        organization_name = safe_name(self.name)
         return '%s://%s/api/organizations/%s/projects' % (request.scheme, request.host, organization_name)
 
     def all_stories(self):
         ''' API link to all an orgs stories
         '''
         # Make a nice org name
-        organization_name = quote(safe_name(self.name).encode('utf8'))
+        organization_name = safe_name(self.name)
         return '%s://%s/api/organizations/%s/stories' % (request.scheme, request.host, organization_name)
 
     def api_id(self):
         ''' Return organization name made safe for use in a URL.
         '''
-        return quote(safe_name(self.name).encode('utf8'))
+        return safe_name(self.name)
 
     def api_url(self):
         ''' API link to itself
@@ -432,7 +431,7 @@ def safe_name(name):
 
         Slashes will be removed, which is incompatible with raw_name().
     '''
-    return name.replace(' ', '-').replace('/', '')
+    return name.replace(' ', '-').replace('/', '-').replace('?','-').replace('#','-')
 
 def raw_name(name):
     ''' Return raw organization name with dashes replaced by spaces.


### PR DESCRIPTION
Hi @pui can you review this?

It removes all the urlquoting and encoding code, replaced by just not adding in any organizations that have those characters.

It also doesn't fail on those errors, just logs them in a new Error table, then continues. Engine light then checks for Errors in that table, and lets us know about them.

The tests are all there, but could probably use a few more comments.
