### PR TITLE
when per_page is set, show it in the 'pages' response; fixes #104

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ from mimetypes import guess_type
 from copy import deepcopy
 from os.path import join
 from math import ceil
+from urllib import urlencode
 
 # -------------------
 # Init
@@ -463,16 +464,24 @@ def pages_dict(page, last):
     pages = dict()
 
     if page > 1:
-        pages['first'] = url
+        pages['first'] = dict()
+        pages['prev'] = dict()
+        if 'per_page' in request.args:
+            pages['first']['per_page'] = request.args['per_page']
+            pages['prev']['per_page'] = request.args['per_page']
 
-    if page == 2:
-        pages['prev'] = url
-    elif page > 2:
-        pages['prev'] = '%s?page=%d' % (url, page - 1)
+    if page > 2:
+        pages['prev']['page'] = page - 1
 
     if page < last:
-        pages['next'] = '%s?page=%d' % (url, page + 1)
-        pages['last'] = '%s?page=%d' % (url, last)
+        pages['next'] = {'page': page + 1}
+        pages['last'] = {'page': last}
+        if 'per_page' in request.args:
+            pages['next']['per_page'] = request.args['per_page']
+            pages['last']['per_page'] = request.args['per_page']
+
+    for key in pages:
+        pages[key] = '%s?%s' % (url, urlencode(pages[key])) if pages[key] else url
 
     return pages
 

--- a/tests.py
+++ b/tests.py
@@ -210,6 +210,10 @@ class ApiTest(unittest.TestCase):
         response = json.loads(response.data)
         assert isinstance(response, dict)
         self.assertEqual(len(response['objects']), 2)
+        self.assertEqual(response['pages']['next'], 'http://localhost/api/projects?per_page=2&page=2')
+        self.assertEqual(response['pages']['last'], 'http://localhost/api/projects?per_page=2&page=2')
+        self.assertNotIn('first', response['pages'])
+        self.assertNotIn('prev', response['pages'])
 
     def test_good_orgs_projects(self):
         organization = OrganizationFactory(name="Code for America")


### PR DESCRIPTION
When a `per_page` query parameter is set, it needs to be included in the `pages` section of the response. This addresses #104.

Feel free to change this around before accepting it if you're not happy with the style... I'm not a native pythonista, and I couldn't come up with a way I thought was better. My first pass was more along the lines of:

``` python
if page > 1:
    if 'per_page' in request.args:
        pages['first'] = '%s?per_page=%s' % (url, request.args['per_page'])
    else:
        pages['first'] = url

if page == 2:
    if 'per_page' in request.args:
        pages['prev'] = '%s?per_page=%s' % (url, request.args['per_page'])
    else:
        pages['prev'] = url
elif page > 2:
    if 'per_page' in request.args:
        pages['prev'] = '%s?page=%d&per_page=%s' % (url, page - 1, request.args['per_page'])
    else:
        pages['prev'] = '%s?' % (url, page - 1)

if page < last:
    if 'per_page' in request.args:
        pages['next'] = '%s?page=%d&per_page=%s' % (url, page + 1, request.args['per_page'])
        pages['last'] = '%s?page=%d&per_page=%s' % (url, last, request.args['per_page'])
    else:
        pages['next'] = '%s?page=%d' % (url, page + 1)
        pages['last'] = '%s?page=%d' % (url, last)
```

...which I thought was harder to read.
