### PR TITLE
Extended organization freshness limit to 16 hours

### DIFF
--- a/app.py
+++ b/app.py
@@ -960,8 +960,8 @@ def well_known_status():
             else:
                 status = 'ok' # is this really okay?
 
-        elif time_since_updated > 6 * 60 * 60:
-            status = 'Oldest organization (%s) updated more than 6 hours ago' % org.name
+        elif time_since_updated > 16 * 60 * 60:
+            status = 'Oldest organization (%s) updated more than 16 hours ago' % org.name
 
         elif remaining_github < 1000:
             status = 'Only %d remaining Github requests' % remaining_github


### PR DESCRIPTION
We are seeing a lot of [status errors](http://codeforamerica.org/api/.well-known/status), but everything is getting updated in time. I've bumped the freshness limit to 16 hours to accommodate the larger number of orgs we are handling.

Attn: @ondrae 
