### PR TITLE
Normalizing cascading configuration, closes #164

### DIFF
--- a/app.py
+++ b/app.py
@@ -227,7 +227,7 @@ class Story(db.Model):
 
     # Relationships
     organization = db.relationship('Organization', single_parent=True, cascade='all, delete-orphan') #child
-    organization_name = db.Column(db.Unicode(), db.ForeignKey('organization.name', ondelete='CASCADE'))
+    organization_name = db.Column(db.Unicode(), db.ForeignKey('organization.name', ondelete='CASCADE'), nullable=False)
 
     def __init__(self, title=None, link=None, type=None, organization_name=None):
         self.title = title
@@ -275,7 +275,7 @@ class Project(db.Model):
 
     # Relationships
     organization = db.relationship('Organization', single_parent=True, cascade='all, delete-orphan') #child
-    organization_name = db.Column(db.Unicode(), db.ForeignKey('organization.name', ondelete='CASCADE'))
+    organization_name = db.Column(db.Unicode(), db.ForeignKey('organization.name', ondelete='CASCADE'), nullable=False)
 
     # Issue has cascade so issues are deleted with their parent projects
     issues = db.relationship('Issue', cascade='save-update, delete') #parent
@@ -333,7 +333,7 @@ class Issue(db.Model):
 
     # Relationships
     project = db.relationship('Project', single_parent=True, cascade='all, delete-orphan') #child
-    project_id = db.Column(db.Integer(), db.ForeignKey('project.id', ondelete='CASCADE'))
+    project_id = db.Column(db.Integer(), db.ForeignKey('project.id', ondelete='CASCADE'), nullable=False, index=True)
 
     labels = db.relationship('Label', cascade='save-update, delete') #parent
 
@@ -415,7 +415,7 @@ class Event(db.Model):
 
     # Relationships
     organization = db.relationship('Organization', single_parent=True, cascade='all, delete-orphan') #child
-    organization_name = db.Column(db.Unicode(), db.ForeignKey('organization.name', ondelete='CASCADE'))
+    organization_name = db.Column(db.Unicode(), db.ForeignKey('organization.name', ondelete='CASCADE'), nullable=False)
 
     def __init__(self, name, event_url, start_time_notz, created_at, utc_offset,
                  organization_name, location=None, end_time_notz=None, description=None):

--- a/app.py
+++ b/app.py
@@ -97,9 +97,9 @@ class Organization(db.Model):
     keep = db.Column(db.Boolean())
 
     # Relationships
-    events = db.relationship('Event', cascade='save-update, delete')
-    stories = db.relationship('Story', cascade='save-update, delete')
-    projects = db.relationship('Project', cascade='save-update, delete')
+    events = db.relationship('Event', cascade='save-update, delete') #parent
+    stories = db.relationship('Story', cascade='save-update, delete') #parent
+    projects = db.relationship('Project', cascade='save-update, delete') #parent
 
     def __init__(self, name, website=None, events_url=None,
                  rss=None, projects_list_url=None, type=None, city=None, latitude=None, longitude=None):
@@ -226,7 +226,7 @@ class Story(db.Model):
     keep = db.Column(db.Boolean())
 
     # Relationships
-    organization = db.relationship('Organization', single_parent=True, cascade='all, delete-orphan')
+    organization = db.relationship('Organization', single_parent=True, cascade='all, delete-orphan') #child
     organization_name = db.Column(db.Unicode(), db.ForeignKey('organization.name', ondelete='CASCADE'))
 
     def __init__(self, title=None, link=None, type=None, organization_name=None):
@@ -274,11 +274,11 @@ class Project(db.Model):
     keep = db.Column(db.Boolean())
 
     # Relationships
-    organization = db.relationship('Organization', single_parent=True, cascade='all, delete-orphan')
+    organization = db.relationship('Organization', single_parent=True, cascade='all, delete-orphan') #child
     organization_name = db.Column(db.Unicode(), db.ForeignKey('organization.name', ondelete='CASCADE'))
 
     # Issue has cascade so issues are deleted with their parent projects
-    issues = db.relationship('Issue', cascade='save-update, delete')
+    issues = db.relationship('Issue', cascade='save-update, delete') #parent
 
     def __init__(self, name, code_url=None, link_url=None,
                  description=None, type=None, categories=None,
@@ -332,10 +332,10 @@ class Issue(db.Model):
     keep = db.Column(db.Boolean())
 
     # Relationships
-    project = db.relationship('Project', single_parent=True, cascade='all, delete-orphan')
+    project = db.relationship('Project', single_parent=True, cascade='all, delete-orphan') #child
     project_id = db.Column(db.Integer(), db.ForeignKey('project.id', ondelete='CASCADE'))
 
-    labels = db.relationship('Label', cascade='save-update, delete')
+    labels = db.relationship('Label', cascade='save-update, delete') #parent
 
     def __init__(self, title, project_id=None, html_url=None, labels=None, body=None):
         self.title = title
@@ -377,7 +377,7 @@ class Label(db.Model):
     color = db.Column(db.Unicode())
     url = db.Column(db.Unicode())
 
-    issue = db.relationship('Issue', single_parent=True, cascade='all, delete-orphan')
+    issue = db.relationship('Issue', single_parent=True, cascade='all, delete-orphan') #child
     issue_id = db.Column(db.Integer, db.ForeignKey('issue.id', ondelete='CASCADE'), nullable=False, index=True)
 
     def __init__(self, name, color, url, issue_id=None):
@@ -414,7 +414,7 @@ class Event(db.Model):
     keep = db.Column(db.Boolean())
 
     # Relationships
-    organization = db.relationship('Organization', single_parent=True, cascade='all, delete-orphan')
+    organization = db.relationship('Organization', single_parent=True, cascade='all, delete-orphan') #child
     organization_name = db.Column(db.Unicode(), db.ForeignKey('organization.name', ondelete='CASCADE'))
 
     def __init__(self, name, event_url, start_time_notz, created_at, utc_offset,

--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ from flask.ext.sqlalchemy import SQLAlchemy
 from sqlalchemy.ext.mutable import Mutable
 from sqlalchemy import types, desc
 from sqlalchemy.sql.expression import func
+from sqlalchemy.orm import backref
 from dictalchemy import make_class_dictable
 from dateutil.tz import tzoffset
 from mimetypes import guess_type
@@ -97,9 +98,7 @@ class Organization(db.Model):
     keep = db.Column(db.Boolean())
 
     # Relationships
-    events = db.relationship('Event', cascade='save-update, delete') #parent
-    stories = db.relationship('Story', cascade='save-update, delete') #parent
-    projects = db.relationship('Project', cascade='save-update, delete') #parent
+    # can contain events, stories, projects (these relationships are defined in the child objects)
 
     def __init__(self, name, website=None, events_url=None,
                  rss=None, projects_list_url=None, type=None, city=None, latitude=None, longitude=None):
@@ -226,7 +225,7 @@ class Story(db.Model):
     keep = db.Column(db.Boolean())
 
     # Relationships
-    organization = db.relationship('Organization', single_parent=True, cascade='all, delete-orphan') #child
+    organization = db.relationship('Organization', single_parent=True, cascade='all, delete-orphan', backref=backref("stories", cascade="save-update, delete")) #child
     organization_name = db.Column(db.Unicode(), db.ForeignKey('organization.name', ondelete='CASCADE'), nullable=False)
 
     def __init__(self, title=None, link=None, type=None, organization_name=None):
@@ -274,11 +273,10 @@ class Project(db.Model):
     keep = db.Column(db.Boolean())
 
     # Relationships
-    organization = db.relationship('Organization', single_parent=True, cascade='all, delete-orphan') #child
+    organization = db.relationship('Organization', single_parent=True, cascade='all, delete-orphan', backref=backref("projects", cascade="save-update, delete")) #child
     organization_name = db.Column(db.Unicode(), db.ForeignKey('organization.name', ondelete='CASCADE'), nullable=False)
 
-    # Issue has cascade so issues are deleted with their parent projects
-    issues = db.relationship('Issue', cascade='save-update, delete') #parent
+    # can contain issues (this relationship is defined in the child object)
 
     def __init__(self, name, code_url=None, link_url=None,
                  description=None, type=None, categories=None,
@@ -327,15 +325,14 @@ class Issue(db.Model):
     id = db.Column(db.Integer(), primary_key=True)
     title = db.Column(db.Unicode())
     html_url = db.Column(db.Unicode())
-    labels = db.Column(JsonType())
     body = db.Column(db.Unicode())
     keep = db.Column(db.Boolean())
 
     # Relationships
-    project = db.relationship('Project', single_parent=True, cascade='all, delete-orphan') #child
+    project = db.relationship('Project', single_parent=True, cascade='all, delete-orphan', backref=backref("issues", cascade="save-update, delete")) #child
     project_id = db.Column(db.Integer(), db.ForeignKey('project.id', ondelete='CASCADE'), nullable=False, index=True)
 
-    labels = db.relationship('Label', cascade='save-update, delete') #parent
+    # can contain labels (this relationship is defined in the child object)
 
     def __init__(self, title, project_id=None, html_url=None, labels=None, body=None):
         self.title = title
@@ -377,7 +374,8 @@ class Label(db.Model):
     color = db.Column(db.Unicode())
     url = db.Column(db.Unicode())
 
-    issue = db.relationship('Issue', single_parent=True, cascade='all, delete-orphan') #child
+    # Relationships
+    issue = db.relationship('Issue', single_parent=True, cascade='all, delete-orphan', backref=backref("labels", cascade="save-update, delete")) #child
     issue_id = db.Column(db.Integer, db.ForeignKey('issue.id', ondelete='CASCADE'), nullable=False, index=True)
 
     def __init__(self, name, color, url, issue_id=None):
@@ -414,7 +412,7 @@ class Event(db.Model):
     keep = db.Column(db.Boolean())
 
     # Relationships
-    organization = db.relationship('Organization', single_parent=True, cascade='all, delete-orphan') #child
+    organization = db.relationship('Organization', single_parent=True, cascade='all, delete-orphan', backref=backref("events", cascade="save-update, delete")) #child
     organization_name = db.Column(db.Unicode(), db.ForeignKey('organization.name', ondelete='CASCADE'), nullable=False)
 
     def __init__(self, name, event_url, start_time_notz, created_at, utc_offset,

--- a/tests.py
+++ b/tests.py
@@ -1074,6 +1074,20 @@ class ApiTest(unittest.TestCase):
         issues = db.session.query(Issue).all()
         self.assertFalse(len(issues))
 
+    def test_create_child_without_parent(self):
+        ''' Test that children created without parents
+            are deleted(?)
+        '''
+
+        self.assertTrue(True)
+
+    def test_set_childs_parent_association_null(self):
+        ''' Test that when a child's parent association
+            is deleted, that the child is destroyed
+        '''
+
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -32,7 +32,7 @@ class ApiTest(unittest.TestCase):
         ProjectFactory(organization_name=organization.name, name=u'Project 2', last_updated='Tue, 01 Jan 2011 00:00:00 GMT')
         ProjectFactory(organization_name=organization.name, name=u'Non Github Project', last_updated='Wed, 01 Jan 2013 00:00:00', github_details=None)
         ProjectFactory(organization_name=organization.name, name=u'Project 3', last_updated='Thu, 01 Jan 2014 00:00:00 GMT')
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/organizations/Code-for-San-Francisco')
         response = json.loads(response.data)
@@ -50,7 +50,7 @@ class ApiTest(unittest.TestCase):
         ProjectFactory(name=u'Project 2', last_updated='Tue, 01 Jan 2011 00:00:00 GMT')
         ProjectFactory(name=u'Non Github Project', last_updated='Wed, 01 Jan 2013 00:00:00', github_details=None)
         ProjectFactory(name=u'Project 3', last_updated='Thu, 01 Jan 2014 00:00:00 GMT')
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/projects')
         response = json.loads(response.data)
@@ -70,7 +70,7 @@ class ApiTest(unittest.TestCase):
         ProjectFactory(organization_name=organization.name, name=u'Project 2', last_updated='Tue, 01 Jan 2011 00:00:00 GMT')
         ProjectFactory(organization_name=organization.name, name=u'Non Github Project', last_updated='Wed, 01 Jan 2013 00:00:00', github_details=None)
         ProjectFactory(organization_name=organization.name, name=u'Project 3', last_updated='Thu, 01 Jan 2014 00:00:00 GMT')
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/organizations/Code-for-San-Francisco/projects')
         response = json.loads(response.data)
@@ -94,7 +94,7 @@ class ApiTest(unittest.TestCase):
         EventFactory(organization_name=organization.name, name=u'New Years', start_time_notz=datetime.now() + timedelta(7))
         EventFactory(organization_name=organization.name, name=u'MLK Day', start_time_notz=datetime.now() + timedelta(25))
         EventFactory(organization_name=organization.name, name=u'Cesar Chavez Day', start_time_notz=datetime.now() + timedelta(37))
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/organizations/Collective%20of%20Ericas')
         response_json = json.loads(response.data)
@@ -139,7 +139,7 @@ class ApiTest(unittest.TestCase):
         EventFactory(organization_name=organization.name, name=u'Event Three', start_time_notz=datetime.now() + timedelta(30))
         EventFactory(organization_name=organization.name, name=u'Event Six', start_time_notz=datetime.now() + timedelta(300))
         EventFactory(organization_name=organization.name, name=u'Event Nine', start_time_notz=datetime.now() + timedelta(3000))
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/events/upcoming_events')
         response_json = json.loads(response.data)
@@ -184,7 +184,7 @@ class ApiTest(unittest.TestCase):
         EventFactory(organization_name=organization.name, name=u'Event Three', start_time_notz=datetime.now() + timedelta(30))
         EventFactory(organization_name=organization.name, name=u'Event Six', start_time_notz=datetime.now() + timedelta(300))
         EventFactory(organization_name=organization.name, name=u'Event Nine', start_time_notz=datetime.now() + timedelta(3000))
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/events/upcoming_events?organization_type=Code for All')
         response_json = json.loads(response.data)
@@ -223,7 +223,7 @@ class ApiTest(unittest.TestCase):
         # Create multiple events, some in the future, one in the past
         EventFactory(organization_name=organization.name, name=u'Past Event', start_time_notz=datetime.now() - timedelta(3000))
         EventFactory(organization_name=organization.name, name=u'Event Three', start_time_notz=datetime.now() + timedelta(30))
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/events/past_events?organization_type=Code for All')
         response_json = json.loads(response.data)
@@ -239,7 +239,7 @@ class ApiTest(unittest.TestCase):
 
         StoryFactory(organization_name=u'Collective of Ericas', title=u'First Story')
         StoryFactory(organization_name=u'Collective of Ericas', title=u'Second Story')
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/organizations/Collective%20of%20Ericas')
         response_json = json.loads(response.data)
@@ -248,7 +248,7 @@ class ApiTest(unittest.TestCase):
 
     def test_headers(self):
         OrganizationFactory()
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/organizations')
         assert response.headers['Access-Control-Allow-Origin']  == '*'
@@ -270,7 +270,7 @@ class ApiTest(unittest.TestCase):
 
     def test_brigade_name_request(self):
         OrganizationFactory(name=u'Code for San Francisco')
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/organizations/Code for San Francisco')
         response = json.loads(response.data)
@@ -289,10 +289,11 @@ class ApiTest(unittest.TestCase):
 
     def test_organizations(self):
         OrganizationFactory()
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/organizations')
         response = json.loads(response.data)
+
         assert isinstance(response, dict)
         assert isinstance(response['pages'], dict)
         assert isinstance(response['total'], int)
@@ -309,12 +310,12 @@ class ApiTest(unittest.TestCase):
         assert isinstance(response['objects'][0]['current_stories'], list)
         assert isinstance(response['objects'][0]['type'], unicode)
         assert isinstance(response['objects'][0]['website'], unicode)
-        assert isinstance(response['objects'][0]['last_updated'], float)
+        assert isinstance(response['objects'][0]['last_updated'], int)
         assert isinstance(response['objects'][0]['started_on'], unicode)
 
     def test_projects(self):
         ProjectFactory()
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/projects')
         response = json.loads(response.data)
@@ -338,7 +339,7 @@ class ApiTest(unittest.TestCase):
         ProjectFactory()
         ProjectFactory()
         ProjectFactory()
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/projects?per_page=2')
         response = json.loads(response.data)
@@ -352,7 +353,7 @@ class ApiTest(unittest.TestCase):
     def test_good_orgs_projects(self):
         organization = OrganizationFactory(name=u'Code for America')
         project = ProjectFactory(organization_name=u'Code for America')
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/organizations/Code for America/projects')
         self.assertEqual(response.status_code, 200)
@@ -361,14 +362,14 @@ class ApiTest(unittest.TestCase):
 
     def test_bad_orgs_projects(self):
         ProjectFactory()
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/organizations/Whatever/projects')
         self.assertEqual(response.status_code, 404)
 
     def test_stories(self):
         StoryFactory()
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/stories')
         response = json.loads(response.data)
@@ -387,7 +388,7 @@ class ApiTest(unittest.TestCase):
         StoryFactory()
         StoryFactory()
         StoryFactory()
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/stories')
         response = json.loads(response.data)
@@ -398,7 +399,7 @@ class ApiTest(unittest.TestCase):
     def test_orgs_stories(self):
         organization = OrganizationFactory(name=u'Code for America')
         story = StoryFactory(organization_name=u'Code for America')
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/organizations/Code for America/stories')
         self.assertEqual(response.status_code, 200)
@@ -409,7 +410,7 @@ class ApiTest(unittest.TestCase):
         organization = OrganizationFactory(name=u'Code for America')
         StoryFactory(organization_name=u'Code for America')
         StoryFactory(organization_name=u'Code for America')
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/organizations/Code for America')
         response = json.loads(response.data)
@@ -421,7 +422,7 @@ class ApiTest(unittest.TestCase):
         StoryFactory(organization_name=u'Code for America')
         StoryFactory(organization_name=u'Code for America')
         StoryFactory(organization_name=u'Code for America')
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/organizations/Code for America/stories')
         response = json.loads(response.data)
@@ -434,7 +435,7 @@ class ApiTest(unittest.TestCase):
         Return all events past/future ordered by oldest to newest
         '''
         EventFactory()
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/events')
         response = json.loads(response.data)
@@ -456,7 +457,7 @@ class ApiTest(unittest.TestCase):
     def test_orgs_events(self):
         organization = OrganizationFactory(name=u'Code for America')
         event = EventFactory(organization_name=u'Code for America')
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/organizations/Code for America/events')
         self.assertEqual(response.status_code, 200)
@@ -564,7 +565,7 @@ class ApiTest(unittest.TestCase):
     def test_dashes_in_slugs(self):
         organization = OrganizationFactory(name=u'Code for America')
         event = EventFactory(organization_name=u'Code for America')
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/organizations/Code-for-America')
         self.assertEqual(response.status_code,200)
@@ -585,7 +586,7 @@ class ApiTest(unittest.TestCase):
         EventFactory(organization_name=organization.name, name=u'Christmas Eve', start_time_notz=datetime.now() - timedelta(1))
         EventFactory(organization_name=organization.name, name=u'New Years', start_time_notz=datetime.now() + timedelta(7))
         EventFactory(organization_name=organization.name, name=u'MLK Day', start_time_notz=datetime.now() + timedelta(25))
-        db.session.flush()
+        db.session.commit()
 
         # Check that future events are returned in the correct order
         response = self.app.get('/api/organizations/International Cat Association/upcoming_events')
@@ -609,7 +610,7 @@ class ApiTest(unittest.TestCase):
         EventFactory(organization_name=organization.name, name=u'Thanksgiving', start_time_notz=datetime.now() - timedelta(30))
         EventFactory(organization_name=organization.name, name=u'Christmas Eve', start_time_notz=datetime.now() - timedelta(1))
         EventFactory(organization_name=organization.name, name=u'New Years', start_time_notz=datetime.now() + timedelta(7))
-        db.session.flush()
+        db.session.commit()
 
         # Check that past events are returned in the correct order
         response = self.app.get('/api/organizations/International Cat Association/past_events')
@@ -672,7 +673,7 @@ class ApiTest(unittest.TestCase):
         issue.labels = [label1]
         issue2.labels = [label2]
 
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/issues/labels/enhancement')
         self.assertEqual(response.status_code, 200)
@@ -767,7 +768,7 @@ class ApiTest(unittest.TestCase):
         issue11 = IssueFactory(project_id=project1.id, title=u'Civic Issue 1.1')
         issue12 = IssueFactory(project_id=project1.id, title=u'Civic Issue 1.2')
         issue21 = IssueFactory(project_id=project2.id, title=u'Civic Issue 2.1')
-        db.session.flush()
+        db.session.commit()
 
         response = self.app.get('/api/organizations/%s/issues' % organization.name)
         self.assertEqual(response.status_code, 200)
@@ -916,12 +917,9 @@ class ApiTest(unittest.TestCase):
         org2 = OrganizationFactory(name=u'Code for San Francisco', type=u'Brigade')
         proj = ProjectFactory(type=u'web', organization_name=u'Code for Africa')
         another_proj = ProjectFactory(type=u'mobile', organization_name=u'Code for San Francisco')
-        awesome_issue = IssueFactory(title=u'Awesome issue')
-        sad_issue = IssueFactory(title=u'Sad issue', body=u'learning swift is sad')
-        db.session.commit()
-
-        awesome_issue.project_id = proj.id
-        sad_issue.project_id = another_proj.id
+        db.session.flush()
+        awesome_issue = IssueFactory(title=u'Awesome issue', project_id=proj.id)
+        sad_issue = IssueFactory(title=u'Sad issue', body=u'learning swift is sad', project_id=another_proj.id)
         db.session.commit()
 
         # Make sure total number of stories is 2
@@ -968,9 +966,13 @@ class ApiTest(unittest.TestCase):
     def test_org_dont_show_issues(self):
         ''' Test that calls to /organizations dont return project issues '''
         from factories import OrganizationFactory, ProjectFactory, IssueFactory
-        OrganizationFactory()
-        ProjectFactory()
-        IssueFactory()
+        organization = OrganizationFactory()
+        db.session.flush()
+
+        project = ProjectFactory(organization_name=organization.name)
+        db.session.flush()
+
+        issue = IssueFactory(project_id=project.id)
         db.session.commit()
 
         response = self.app.get('/api/organizations')
@@ -999,7 +1001,7 @@ class ApiTest(unittest.TestCase):
         db.session.flush()
 
         db.session.execute('DELETE FROM issue')
-        db.session.flush()
+        db.session.commit()
         labels = db.session.query(Label).all()
         self.assertFalse(len(labels))
 
@@ -1011,7 +1013,7 @@ class ApiTest(unittest.TestCase):
         db.session.flush()
 
         db.session.execute('DELETE FROM project')
-        db.session.flush()
+        db.session.commit()
         labels = db.session.query(Label).all()
         self.assertFalse(len(labels))
 
@@ -1026,7 +1028,7 @@ class ApiTest(unittest.TestCase):
         db.session.flush()
 
         db.session.execute('DELETE FROM organization')
-        db.session.flush()
+        db.session.commit()
         labels = db.session.query(Label).all()
         self.assertFalse(len(labels))
 
@@ -1045,14 +1047,14 @@ class ApiTest(unittest.TestCase):
         issue = IssueFactory(title=u'TEST ISSUE', project_id=project.id)
         another_issue = IssueFactory(title=u'ANOTHER TEST ISSUE', project_id=project.id)
         a_third_issue = IssueFactory(title=u'A THIRD TEST ISSUE', project_id=project.id)
-        db.session.flush()
+        db.session.commit()
 
         # make sure the issues are in the db
         issues = db.session.query(Issue).all()
         self.assertTrue(len(issues) == 3)
 
         db.session.execute('DELETE FROM project')
-        db.session.flush()
+        db.session.commit()
         issues = db.session.query(Issue).all()
         self.assertFalse(len(issues))
 
@@ -1063,14 +1065,14 @@ class ApiTest(unittest.TestCase):
         issue = IssueFactory(title=u'TEST ISSUE', project_id=project.id)
         another_issue = IssueFactory(title=u'ANOTHER TEST ISSUE', project_id=project.id)
         a_third_issue = IssueFactory(title=u'A THIRD TEST ISSUE', project_id=project.id)
-        db.session.flush()
+        db.session.commit()
 
         # make sure the issues are in the db
         issues = db.session.query(Issue).all()
         self.assertTrue(len(issues) == 3)
 
         db.session.execute('DELETE FROM organization')
-        db.session.flush()
+        db.session.commit()
         issues = db.session.query(Issue).all()
         self.assertFalse(len(issues))
 


### PR DESCRIPTION
Foreign key relationships and cascades are now set up in the children, mimicking the way PostgreSQL does it. I also made all foreign keys non nullable, standardized the way we use flush() vs commit() in our tests, and wrote some new tests to test the above.