### PR TITLE
using repo name for missing project names, closes #168

### DIFF
--- a/run_update.py
+++ b/run_update.py
@@ -355,7 +355,7 @@ def update_project_info(project):
                 last_updated = datetime.strftime(existing_project.last_updated, "%a, %d %b %Y %H:%M:%S GMT")
                 got = get_github_api(repo_url, headers={"If-Modified-Since": last_updated})
             else:
-                # In rare cases, a project can be saved with out a last_updated.
+                # In rare cases, a project can be saved without a last_updated.
                 got = get_github_api(repo_url)
 
         else:


### PR DESCRIPTION
added test verifying that missing project names are filled with github repo names