### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/codeforamerica/cfapi.png?label=ready&title=Ready)](https://waffle.io/codeforamerica/cfapi)
 [![Build Status](https://travis-ci.org/codeforamerica/cfapi.svg?branch=master)](https://travis-ci.org/codeforamerica/cfapi)
 
 # The Code for America API


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/codeforamerica/cfapi

This was requested by a real person (user ondrae) on waffle.io, we're not trying to spam you.