### PR TITLE
[FEATURE] Search projects via full-text search

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,20 +18,23 @@ import requests
 from flask.ext.heroku import Heroku
 from flask.ext.sqlalchemy import SQLAlchemy
 from sqlalchemy.ext.mutable import Mutable
+from sqlalchemy.ext.compiler import compiles
 from sqlalchemy import types, desc
 from sqlalchemy.sql.expression import func
 from sqlalchemy.orm import backref
+from sqlalchemy import event, DDL
+from sqlalchemy import types
 from dictalchemy import make_class_dictable
 from dateutil.tz import tzoffset
 from flask.ext.script import Manager
 from flask.ext.migrate import Migrate, MigrateCommand
-
 
 # -------------------
 # Init
 # -------------------
 
 app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'postgres://postgres@localhost/cfapi'
 heroku = Heroku(app)
 db = SQLAlchemy(app)
 
@@ -77,6 +80,17 @@ class JsonType(Mutable, types.TypeDecorator):
             # default can also be a list
             return {}
 
+class TSVectorType(types.TypeDecorator):
+    ''' TSVECTOR wrapper type for database storage.
+
+        References:
+        http://stackoverflow.com/questions/13837111/tsvector-in-sqlalchemy
+    '''
+    impl = types.UnicodeText
+
+@compiles(TSVectorType, 'postgresql')
+def compile_tsvector(element, compiler, **kw):
+    return 'tsvector'
 
 # -------------------
 # Models
@@ -274,6 +288,8 @@ class Project(db.Model):
     last_updated = db.Column(db.DateTime())
     last_updated_issues = db.Column(db.Unicode())
     keep = db.Column(db.Boolean())
+    tsv_body = db.Column(TSVectorType())
+
 
     # Relationships
     organization = db.relationship('Organization', single_parent=True, cascade='all, delete-orphan', backref=backref("projects", cascade="save-update, delete")) #child
@@ -297,6 +313,8 @@ class Project(db.Model):
         self.organization_name = organization_name
         self.keep = True
 
+
+
     def api_url(self):
         ''' API link to itself
         '''
@@ -319,6 +337,18 @@ class Project(db.Model):
             project_dict['issues'] = [o.asdict() for o in db.session.query(Issue).filter(Issue.project_id == project_dict['id']).all()]
 
         return project_dict
+
+tbl = Project.__table__
+# Index the tsvector column
+db.Index('index_project_tsv_body', tbl.c.tsv_body, postgresql_using='gin')
+
+# Trigger to populate the search index column
+trig_ddl = DDL("""
+    CREATE TRIGGER tsvupdate_projects_trigger BEFORE INSERT OR UPDATE ON project FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger(tsv_body, 'pg_catalog.english', name, description, categories);
+""")
+# Initialize the trigger after table is created
+event.listen(tbl, 'after_create', trig_ddl.execute_if(dialect='postgresql'))
+
 
 class Issue(db.Model):
     '''
@@ -751,12 +781,16 @@ def get_projects(id=None):
         if 'organization' in attr:
             org_attr = attr.split('_')[1]
             query = query.join(Project.organization).filter(getattr(Organization, org_attr).ilike('%%%s%%' % value))
+        elif 'q' in attr:
+            query = query.filter(Project.tsv_body.match('%s' % value, postgresql_regconfig='english'))
         else:
             query = query.filter(getattr(Project, attr).ilike('%%%s%%' % value))
 
     query = query.order_by(desc(Project.last_updated))
     response = paged_results(query, int(request.args.get('page', 1)), int(request.args.get('per_page', 10)), querystring)
     return jsonify(response)
+
+
 
 @app.route('/api/issues')
 @app.route('/api/issues/<int:id>')

--- a/app.py
+++ b/app.py
@@ -792,9 +792,11 @@ def get_projects(id=None):
             org_attr = attr.split('_')[1]
             query = query.join(Project.organization).filter(getattr(Organization, org_attr).ilike('%%%s%%' % value))
         elif 'q' in attr:
-            query = query.filter("project.tsv_body @@ plainto_tsquery('%s')" % value)
-            relevance_ordering_filter = func.ts_rank(Project.tsv_body,func.plainto_tsquery('%s'%value))
-            ordering_filter_name = 'relevance'
+            # Returns all results if the value is empty
+            if value:
+                query = query.filter("project.tsv_body @@ plainto_tsquery('%s')" % value)
+                relevance_ordering_filter = func.ts_rank(Project.tsv_body,func.plainto_tsquery('%s'%value))
+                ordering_filter_name = 'relevance'
         elif 'only_ids' in attr:
             query = query.with_entities(Project.id)
         elif 'sort_by' in attr:

--- a/app.py
+++ b/app.py
@@ -34,7 +34,6 @@ from flask.ext.migrate import Migrate, MigrateCommand
 # -------------------
 
 app = Flask(__name__)
-app.config['SQLALCHEMY_DATABASE_URI'] = 'postgres://postgres@localhost/cfapi'
 heroku = Heroku(app)
 db = SQLAlchemy(app)
 
@@ -568,7 +567,7 @@ def paged_results(query, page, per_page, querystring=''):
         model_dicts = [o.id for o in query.limit(per_page).offset(offset)]
     else:
         model_dicts = [o.asdict(True) for o in query.limit(per_page).offset(offset)]
-        
+
 
     return dict(total=total, pages=pages_dict(page, last, querystring), objects=model_dicts)
 

--- a/app.py
+++ b/app.py
@@ -766,7 +766,7 @@ def get_projects(id=None):
     '''
 
     filters, querystring = get_query_params(request.args)
-    
+
     if id:
         # Get one named project.
         filter = Project.id == id
@@ -780,7 +780,12 @@ def get_projects(id=None):
     # Get a bunch of projects.
     query = db.session.query(Project)
     # Default ordering of results
-    ordering = desc(Project.last_updated)
+    last_updated_ordering_filter = Project.last_updated
+    relevance_ordering_filter = None
+    ordering_filter_name = 'last_updated'
+    ordering_filter = last_updated_ordering_filter
+    ordering_dir = 'desc'
+    ordering = None
 
     for attr, value in filters.iteritems():
         if 'organization' in attr:
@@ -788,12 +793,32 @@ def get_projects(id=None):
             query = query.join(Project.organization).filter(getattr(Organization, org_attr).ilike('%%%s%%' % value))
         elif 'q' in attr:
             query = query.filter("project.tsv_body @@ plainto_tsquery('%s')" % value)
-            ordering = desc(func.ts_rank(Project.tsv_body,func.plainto_tsquery('%s'%value)))
+            relevance_ordering_filter = func.ts_rank(Project.tsv_body,func.plainto_tsquery('%s'%value))
+            ordering_filter_name = 'relevance'
         elif 'only_ids' in attr:
             query = query.with_entities(Project.id)
+        elif 'sort_by' in attr:
+            if(value == 'relevance'):
+                ordering_filter_name = 'relevance'
+            else:
+                ordering_filter_name = 'last_updated'
+        elif 'sort_dir' in attr:
+            if(value == 'asc'):
+                ordering_dir = 'asc'
+            else:
+                ordering_dir = 'desc'
         else:
             query = query.filter(getattr(Project, attr).ilike('%%%s%%' % value))
 
+    if(ordering_filter_name == 'last_updated'):
+        ordering_filter = last_updated_ordering_filter
+    elif(ordering_filter_name == 'relevance' and dir(relevance_ordering_filter) != dir(None)):
+        ordering_filter = relevance_ordering_filter
+
+    if(ordering_dir == 'desc'):
+        ordering = ordering_filter.desc()
+    else:
+        ordering = ordering_filter.asc()
     query = query.order_by(ordering)
     response = paged_results(query, int(request.args.get('page', 1)), int(request.args.get('per_page', 10)), querystring)
     return jsonify(response)

--- a/app.py
+++ b/app.py
@@ -566,7 +566,12 @@ def paged_results(query, page, per_page, querystring=''):
     if(querystring.find("only_ids") != -1):
         model_dicts = [o.id for o in query.limit(per_page).offset(offset)]
     else:
-        model_dicts = [o.asdict(True) for o in query.limit(per_page).offset(offset)]
+        model_dicts = []
+        for o in query.limit(per_page).offset(offset):
+            obj = o.asdict(True)
+            # Remove some fields from the API
+            obj.pop('tsv_body', None)
+            model_dicts.append(obj)
     return dict(total=total, pages=pages_dict(page, last, querystring), objects=model_dicts)
 
 def is_safe_name(name):

--- a/app.py
+++ b/app.py
@@ -760,14 +760,13 @@ def get_orgs_issues(organization_name, labels=None):
     return jsonify(response)
 
 @app.route('/api/projects')
-@app.route('/api/search/projects')
 @app.route('/api/projects/<int:id>')
 def get_projects(id=None):
     ''' Regular response option for projects.
     '''
 
     filters, querystring = get_query_params(request.args)
-
+    
     if id:
         # Get one named project.
         filter = Project.id == id

--- a/factories.py
+++ b/factories.py
@@ -35,8 +35,7 @@ class ProjectFactory(SQLAlchemyModelFactory):
     categories = factory.LazyAttribute(lambda n: choice([u'housing', u'community engagement', u'criminal justice', u'education']))
     github_details = {'repo': u'git@github.com:codeforamerica/civic-project.git'}
     organization_name = factory.LazyAttribute(lambda e: OrganizationFactory().name)
-
-
+    
 class EventFactory(SQLAlchemyModelFactory):
     FACTORY_FOR = Event
     FACTORY_SESSION = db.session

--- a/run_update_test.py
+++ b/run_update_test.py
@@ -585,7 +585,7 @@ class RunUpdateTestCase(unittest.TestCase):
         '''
         from app import Label
         import run_update
-        
+
         self.setup_mock_rss_response()
 
         with HTTMock(self.response_content):

--- a/tests.py
+++ b/tests.py
@@ -473,6 +473,16 @@ class ApiTest(unittest.TestCase):
         self.assertEqual(response['total'], 1)
         self.assertEqual(len(response['objects']), 1)
 
+    def test_project_search_tsv_body_not_in_response(self):
+        ProjectFactory(
+            description=u'ruby on rails'
+        )
+        db.session.commit()
+        response = self.app.get('/api/projects?q=')
+        response = json.loads(response.data)
+        self.assertEqual(len(response['objects']), 1)
+        self.assertEqual(response['objects'][0]['tsv_body'], None)
+
     def test_pagination(self):
         ProjectFactory()
         ProjectFactory()

--- a/tests.py
+++ b/tests.py
@@ -344,7 +344,7 @@ class ApiTest(unittest.TestCase):
             description=u'Coder'
         )
         db.session.commit()
-        response = self.app.get('/api/search/projects?q=ruby')
+        response = self.app.get('/api/projects?q=ruby')
         response = json.loads(response.data)
         assert isinstance(response['total'], int)
         assert isinstance(response['objects'], list)
@@ -356,7 +356,7 @@ class ApiTest(unittest.TestCase):
             description=u'ruby'
         )
         db.session.commit()
-        response = self.app.get('/api/search/projects?q=ruby')
+        response = self.app.get('/api/projects?q=ruby')
         response = json.loads(response.data)
         assert isinstance(response['total'], int)
         assert isinstance(response['objects'], list)
@@ -368,7 +368,7 @@ class ApiTest(unittest.TestCase):
             description=u'ruby on rails'
         )
         db.session.commit()
-        response = self.app.get('/api/search/projects?q=ruby on rails')
+        response = self.app.get('/api/projects?q=ruby on rails')
         response = json.loads(response.data)
         assert isinstance(response['total'], int)
         assert isinstance(response['objects'], list)
@@ -380,7 +380,7 @@ class ApiTest(unittest.TestCase):
             description=u'ruby on rails'
         )
         db.session.commit()
-        response = self.app.get('/api/search/projects?q=ruby')
+        response = self.app.get('/api/projects?q=ruby')
         response = json.loads(response.data)
         assert isinstance(response['total'], int)
         assert isinstance(response['objects'], list)
@@ -392,7 +392,7 @@ class ApiTest(unittest.TestCase):
             description=u'ruby on rails'
         )
         db.session.commit()
-        response = self.app.get('/api/search/projects?q=joomla')
+        response = self.app.get('/api/projects?q=joomla')
         response = json.loads(response.data)
         assert isinstance(response['total'], int)
         assert isinstance(response['objects'], list)
@@ -409,7 +409,7 @@ class ApiTest(unittest.TestCase):
             last_updated=datetime.now() - timedelta(1)
         )
         db.session.commit()
-        response = self.app.get('/api/search/projects?q=ruby')
+        response = self.app.get('/api/projects?q=ruby')
         response = json.loads(response.data)
         assert isinstance(response['total'], int)
         assert isinstance(response['objects'], list)
@@ -422,7 +422,7 @@ class ApiTest(unittest.TestCase):
         db.session.commit()
         project_id = project.id
 
-        response = self.app.get('/api/search/projects?q=ruby&only_ids=true')
+        response = self.app.get('/api/projects?q=ruby&only_ids=true')
         response = json.loads(response.data)
         assert isinstance(response['total'], int)
         assert isinstance(response['objects'], list)

--- a/tests.py
+++ b/tests.py
@@ -339,6 +339,17 @@ class ApiTest(unittest.TestCase):
         assert isinstance(response['objects'][0]['organization_name'], unicode)
         assert isinstance(response['objects'][0]['type'], unicode)
 
+    def test_project_search_one_query_param(self):
+        ProjectFactory(
+            description=u'Coder'
+        )
+        db.session.commit()
+
+        response = self.app.get('/api/projects?q=ruby')
+        response = json.loads(response.data)
+        self.assertEqual(len(response['objects']), 0)
+
+
     def test_pagination(self):
         ProjectFactory()
         ProjectFactory()

--- a/tests.py
+++ b/tests.py
@@ -461,6 +461,18 @@ class ApiTest(unittest.TestCase):
         assert isinstance(response['objects'][0], int)
         self.assertEqual(response['objects'][0], project_id)
 
+    def test_project_search_empty_string(self):
+        ProjectFactory(
+            description=u'ruby on rails'
+        )
+        db.session.commit()
+        response = self.app.get('/api/projects?q=')
+        response = json.loads(response.data)
+        assert isinstance(response['total'], int)
+        assert isinstance(response['objects'], list)
+        self.assertEqual(response['total'], 1)
+        self.assertEqual(len(response['objects']), 1)
+
     def test_pagination(self):
         ProjectFactory()
         ProjectFactory()

--- a/tests.py
+++ b/tests.py
@@ -405,11 +405,43 @@ class ApiTest(unittest.TestCase):
             last_updated=datetime.now() - timedelta(10)
         )
         ProjectFactory(
-            description=u'joomla',
+            description=u'ruby on grails',
             last_updated=datetime.now() - timedelta(1)
         )
         db.session.commit()
         response = self.app.get('/api/projects?q=ruby')
+        response = json.loads(response.data)
+        assert isinstance(response['total'], int)
+        assert isinstance(response['objects'], list)
+        self.assertEqual(response['objects'][0]['description'], 'ruby on rails')
+
+    def test_project_search_order_by_last_updated(self):
+        ProjectFactory(
+            description=u'ruby on rails',
+            last_updated=datetime.now() - timedelta(10)
+        )
+        ProjectFactory(
+            description=u'ruby on grails',
+            last_updated=datetime.now() - timedelta(1)
+        )
+        db.session.commit()
+        response = self.app.get('/api/projects?q=ruby&sort_by=last_updated')
+        response = json.loads(response.data)
+        assert isinstance(response['total'], int)
+        assert isinstance(response['objects'], list)
+        self.assertEqual(response['objects'][0]['description'], 'ruby on grails')
+
+    def test_project_search_order_by_last_updated_sort_asc(self):
+        ProjectFactory(
+            description=u'ruby on rails',
+            last_updated=datetime.now() - timedelta(10)
+        )
+        ProjectFactory(
+            description=u'ruby on grails',
+            last_updated=datetime.now() - timedelta(1)
+        )
+        db.session.commit()
+        response = self.app.get('/api/projects?q=ruby&sort_by=last_updated&sort_dir=asc')
         response = json.loads(response.data)
         assert isinstance(response['total'], int)
         assert isinstance(response['objects'], list)

--- a/tests.py
+++ b/tests.py
@@ -481,7 +481,7 @@ class ApiTest(unittest.TestCase):
         response = self.app.get('/api/projects?q=')
         response = json.loads(response.data)
         self.assertEqual(len(response['objects']), 1)
-        self.assertEqual(response['objects'][0]['tsv_body'], None)
+        self.assertFalse( 'tsv_body' in response['objects'][0])
 
     def test_pagination(self):
         ProjectFactory()


### PR DESCRIPTION
This feature allows the API to accept full text search queries to the endpoint `/api/projects` using query parameter `q`. It indexes `name`, `categories` and `description` fields. It also allows use to get the results only as ids by passing the `only_ids` parameter.