### PR TITLE
Read status column from spreadsheets

### DIFF
--- a/run_update.py
+++ b/run_update.py
@@ -34,7 +34,7 @@ requests_log.setLevel(logging.WARNING)
 # They should be lists of organizations you want included at /organizations
 # columns should be name, website, events_url, rss, projects_list_url, city, latitude, longitude, type
 # set use_test to True to use test_org_sources.csv instead of org_sources.csv
-use_test = True
+use_test = False
 ORG_SOURCES = u'{}org_sources.csv'.format(u'test_' if use_test else u'')
 
 if 'GITHUB_TOKEN' in os.environ:

--- a/run_update.py
+++ b/run_update.py
@@ -287,8 +287,8 @@ def non_github_project_update_time(project):
 
         Set the last_updated timestamp.
     '''
-    def updated_project_timestamp():
-        project['last_updated'] = datetime.now().strftime("%a, %d %b %Y %H:%M:%S %Z")
+    def get_updated_timestamp():
+        return datetime.now().strftime("%a, %d %b %Y %H:%M:%S %Z")
 
     existing_project = db.session.query(Project).filter(Project.name == project['name']).first()
 
@@ -299,11 +299,11 @@ def non_github_project_update_time(project):
         # unless one of the fields has been updated
         for key, value in project.iteritems():
             if project[key] != existing_project.__dict__[key]:
-                updated_project_timestamp()
+                project['last_updated'] = get_updated_timestamp()
 
     else:
         # Set a date when we first see a non-github project
-        updated_project_timestamp()
+        project['last_updated'] = get_updated_timestamp()
 
     return project
 

--- a/run_update.py
+++ b/run_update.py
@@ -287,6 +287,9 @@ def non_github_project_update_time(project):
 
         Set the last_updated timestamp.
     '''
+    def updated_project_timestamp():
+        project['last_updated'] = datetime.now().strftime("%a, %d %b %Y %H:%M:%S %Z")
+
     existing_project = db.session.query(Project).filter(Project.name == project['name']).first()
 
     if existing_project:
@@ -294,25 +297,13 @@ def non_github_project_update_time(project):
         project['last_updated'] = existing_project.last_updated
 
         # unless one of the fields has been updated
-        if 'description' in project:
-            if project['description'] != existing_project.description:
-                project['last_updated'] = datetime.now().strftime("%a, %d %b %Y %H:%M:%S %Z")
-        if 'categories' in project:
-            if project['categories'] != existing_project.categories:
-                project['last_updated'] = datetime.now().strftime("%a, %d %b %Y %H:%M:%S %Z")
-        if 'type' in project:
-            if project['type'] != existing_project.type:
-                project['last_updated'] = datetime.now().strftime("%a, %d %b %Y %H:%M:%S %Z")
-        if 'link_url' in project:
-            if project['link_url'] != existing_project.link_url:
-                project['last_updated'] = datetime.now().strftime("%a, %d %b %Y %H:%M:%S %Z")
-        if 'status' in project:
-            if project['status'] != existing_project.status:
-                project['last_updated'] = datetime.now().strftime("%a, %d %b %Y %H:%M:%S %Z")
+        for key, value in project.iteritems():
+            if project[key] != existing_project.__dict__[key]:
+                updated_project_timestamp()
 
     else:
         # Set a date when we first see a non-github project
-        project['last_updated'] = datetime.now().strftime("%a, %d %b %Y %H:%M:%S %Z")
+        updated_project_timestamp()
 
     return project
 

--- a/run_update.py
+++ b/run_update.py
@@ -225,7 +225,7 @@ def get_projects(organization):
                 return []
 
             # If its a csv
-            if "csv" in organization.projects_list_url:
+            if "csv" in organization.projects_list_url and ('content-type' in response.headers and 'text/csv' in response.headers['content-type']):
                 data = response.content.splitlines()
                 projects = list(DictReader(data, dialect='excel'))
                 # convert all the values to unicode
@@ -456,6 +456,7 @@ def update_project_info(project):
             project['github_details']['participation'] = got.json()['all']
         except:
             project['github_details']['participation'] = [0] * 50
+
     return project
 
 def get_issues_for_project(project):

--- a/run_update.py
+++ b/run_update.py
@@ -225,7 +225,7 @@ def get_projects(organization):
                 return []
 
             # If its a csv
-            if "csv" in organization.projects_list_url and ('content-type' in response.headers and 'text/csv' in response.headers['content-type']):
+            if "csv" in organization.projects_list_url and (('content-type' in response.headers and 'text/csv' in response.headers['content-type']) or 'content-type' not in response.headers):
                 data = response.content.splitlines()
                 projects = list(DictReader(data, dialect='excel'))
                 # convert all the values to unicode

--- a/run_update.py
+++ b/run_update.py
@@ -33,7 +33,9 @@ requests_log.setLevel(logging.WARNING)
 # Org sources can be csv or yaml
 # They should be lists of organizations you want included at /organizations
 # columns should be name, website, events_url, rss, projects_list_url, city, latitude, longitude, type
-ORG_SOURCES = 'org_sources.csv'
+# set use_test to True to use test_org_sources.csv instead of org_sources.csv
+use_test = True
+ORG_SOURCES = u'{}org_sources.csv'.format(u'test_' if use_test else u'')
 
 if 'GITHUB_TOKEN' in os.environ:
     github_auth = (os.environ['GITHUB_TOKEN'], '')

--- a/run_update_test.py
+++ b/run_update_test.py
@@ -68,9 +68,9 @@ class RunUpdateTestCase(unittest.TestCase):
         if url.geturl() == 'http://example.com/cfa-projects.csv':
             project_lines = ['''Name,description,link_url,code_url,type,categories,status''', ''',,,https://github.com/codeforamerica/cityvoice,,,''', ''',,,https://github.com/codeforamerica/bizfriendly-web,,,''']
             if self.results_state == 'before':
-                return response(200, '''\n'''.join(project_lines[0:3]))
+                return response(200, '''\n'''.join(project_lines[0:3]), {'content-type': 'text/csv; charset=UTF-8'})
             elif self.results_state == 'after':
-                return response(200, '''\n'''.join(project_lines[0:2]))
+                return response(200, '''\n'''.join(project_lines[0:2]), {'content-type': 'text/csv; charset=UTF-8'})
 
         # json of project descriptions
         elif url.geturl() == 'https://api.github.com/users/codeforamerica/repos':
@@ -156,11 +156,11 @@ class RunUpdateTestCase(unittest.TestCase):
 
         # csv of projects (philly)
         elif url.geturl() == 'http://codeforphilly.org/projects.csv':
-                return response(200, '''"name","description","link_url","code_url","type","categories","status"\r\n"OpenPhillyGlobe","\"Google Earth for Philadelphia\" with open source and open transit data.","http://cesium.agi.com/OpenPhillyGlobe/","http://google.com","","",""''')
+                return response(200, '''"name","description","link_url","code_url","type","categories","status"\r\n"OpenPhillyGlobe","\"Google Earth for Philadelphia\" with open source and open transit data.","http://cesium.agi.com/OpenPhillyGlobe/","http://google.com","","",""''', {'content-type': 'text/csv; charset=UTF-8'})
 
         # csv of projects (austin)
         elif url.geturl() == 'http://openaustin.org/projects.csv':
-                return response(200, '''name,description,link_url,code_url,type,categories,status\nHack Task Aggregator,"Web application to aggregate tasks across projects that are identified for ""hacking"".",,,web service,"project management, civic hacking",In Progress''')
+                return response(200, '''name,description,link_url,code_url,type,categories,status\nHack Task Aggregator,"Web application to aggregate tasks across projects that are identified for ""hacking"".",,,web service,"project management, civic hacking",In Progress''', {'content-type': 'text/csv; charset=UTF-8'})
 
         else:
             raise Exception('Asked for unknown URL ' + url.geturl())
@@ -514,7 +514,7 @@ class RunUpdateTestCase(unittest.TestCase):
 
         def overwrite_response_content(url, request):
             if url.geturl() == 'http://codeforphilly.org/projects.csv':
-                return response(200, '''"name","description","link_url","code_url","type","categories","status"\r\n"Philly Map of Shame","PHL Map of Shame is a citizen-led project to map the impact of the School Reform Commission\xe2\x80\x99s \xe2\x80\x9cdoomsday budget\xe2\x80\x9d on students and parents. We will visualize complaints filed with the Pennsylvania Department of Education.","http://phillymapofshame.org","","","Education, CivicEngagement","In Progress"''')
+                return response(200, '''"name","description","link_url","code_url","type","categories","status"\r\n"Philly Map of Shame","PHL Map of Shame is a citizen-led project to map the impact of the School Reform Commission\xe2\x80\x99s \xe2\x80\x9cdoomsday budget\xe2\x80\x9d on students and parents. We will visualize complaints filed with the Pennsylvania Department of Education.","http://phillymapofshame.org","","","Education, CivicEngagement","In Progress"''', {'content-type': 'text/csv; charset=UTF-8'})
 
         with HTTMock(self.response_content):
             with HTTMock(overwrite_response_content):
@@ -556,7 +556,7 @@ class RunUpdateTestCase(unittest.TestCase):
 
         def overwrite_response_content(url, request):
             if url.geturl() == 'http://organization.org/projects.csv':
-                return response(200, '''name,description,link_url\n,,http://fakeprojectone.com\n,,,http://whatever.com/testproject''')
+                return response(200, '''name,description,link_url\n,,http://fakeprojectone.com\n,,,http://whatever.com/testproject''', {'content-type': 'text/csv; charset=UTF-8'})
 
         with HTTMock(self.response_content):
             with HTTMock(overwrite_response_content):

--- a/run_update_test.py
+++ b/run_update_test.py
@@ -553,7 +553,7 @@ class RunUpdateTestCase(unittest.TestCase):
         from factories import OrganizationFactory, ProjectFactory
 
         philly = OrganizationFactory(name=u'Code for Philly', projects_list_url=u'http://codeforphilly.org/projects.csv')
-        old_project = ProjectFactory(name=u'Philly Map of Shame', organization_name=u'Code for Philly', description=u'PHL Map of Shame is a citizen-led project to map the impact of the School Reform Commission\u2019s \u201cdoomsday budget\u201d on students and parents. We will visualize complaints filed with the Pennsylvania Department of Education.', categories=u'Education, CivicEngagement', type=u'', link_url=u'http://phillymapofshame.org', status=u'In Progress')
+        old_project = ProjectFactory(name=u'Philly Map of Shame', organization_name=u'Code for Philly', description=u'PHL Map of Shame is a citizen-led project to map the impact of the School Reform Commission\u2019s \u201cdoomsday budget\u201d on students and parents. We will visualize complaints filed with the Pennsylvania Department of Education.', categories=u'Education, CivicEngagement', type=u'', link_url=u'http://phillymapofshame.org', code_url=u'', status=u'In Progress')
         self.db.session.flush()
 
         def overwrite_response_content(url, request):


### PR DESCRIPTION
I verified that if a status column is included in a project spreadsheet it is ingested, updated, etc., and that it shows up accurately in the API output and is searchable. I also fixed a bug where values changed in the org spreadsheet weren't getting updated if the linked GitHub project hadn't been updated.

I did all this work with a [test spreadsheet](https://docs.google.com/spreadsheets/d/1a4NmpHSAR66F87u2N1zP-tmEIhcLJYmnqVD_Rk9rWtw/edit#gid=0) because I don't have edit access to any of the org spreadsheets linked from the brigade spreadsheet.

When the owners of those spreadsheets add a status column and values, they'll be reflected in the API.

also fixes #206, a bug I found while researching the problem.