### PR TITLE
WIP Improved project search

### DIFF
--- a/app.py
+++ b/app.py
@@ -397,6 +397,7 @@ db.Index('index_project_tsv_body', tbl.c.tsv_body, postgresql_using='gin')
 
 # Trigger to populate the search index column
 trig_ddl = DDL("""
+    DROP FUNCTION IF EXISTS project_search_trigger();
     CREATE FUNCTION project_search_trigger() RETURNS trigger AS $$
     begin
       new.tsv_body :=

--- a/migrations/versions/4f685c062cff_improved_project_search.py
+++ b/migrations/versions/4f685c062cff_improved_project_search.py
@@ -1,0 +1,46 @@
+""" Much improved project search.
+
+Revision ID: 4f685c062cff
+Revises: 8081a5906af
+Create Date: 2015-09-15 21:53:02.468239
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4f685c062cff'
+down_revision = '8081a5906af'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    droptrigger = "DROP TRIGGER IF EXISTS tsvupdate_projects_trigger ON project"
+    droptriggerfunc = "DROP FUNCTION IF EXISTS project_search_trigger()"
+    createtriggerfunc = '''
+        CREATE FUNCTION project_search_trigger() RETURNS trigger AS $$
+        begin
+          new.tsv_body :=
+             setweight(to_tsvector('pg_catalog.english', coalesce(new.status,'')), 'A') ||
+             setweight(to_tsvector('pg_catalog.english', coalesce(new.tags,'')), 'A') ||
+             setweight(to_tsvector('pg_catalog.english', coalesce(new.name,'')), 'B') ||
+             setweight(to_tsvector('pg_catalog.english', coalesce(new.description,'')), 'B');
+          return new;
+        end
+        $$ LANGUAGE plpgsql;
+        '''
+    createtrigger = "CREATE TRIGGER tsvupdate_projects_trigger BEFORE INSERT OR UPDATE ON project FOR EACH ROW EXECUTE PROCEDURE project_search_trigger();"
+    op.execute(droptrigger)
+    op.execute(droptriggerfunc)
+    op.execute(createtriggerfunc)
+    op.execute(createtrigger)
+
+
+def downgrade():
+    droptrigger = "DROP TRIGGER IF EXISTS tsvupdate_projects_trigger ON project"
+    droptriggerfunc = "DROP FUNCTION IF EXISTS project_search_trigger()"
+    createtrigger = "CREATE TRIGGER tsvupdate_projects_trigger BEFORE INSERT OR UPDATE ON project FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger(tsv_body, 'pg_catalog.english', name, description, type, categories, tags, github_details, status);"
+    op.execute(droptrigger)
+    op.execute(droptriggerfunc)
+    op.execute(createtrigger)
+

--- a/test/integration/test_projects.py
+++ b/test/integration/test_projects.py
@@ -381,39 +381,6 @@ class TestProjects(IntegrationTest):
         self.assertEqual(len(org_project_response['objects']), 1)
         self.assertEqual(org_project_response['objects'][0]['name'], 'My Cool Project')
 
-    def test_project_search_includes_type(self):
-        ''' The type field is included in search results from the project and org/project endpoints
-        '''
-        organization = OrganizationFactory(name=u"Code for San Francisco")
-        ProjectFactory(organization_name=organization.name, type=u'mobile app')
-        ProjectFactory(organization_name=organization.name, type=u'data portal')
-        db.session.commit()
-        project_response = self.app.get('/api/projects?q=portal')
-        project_response = json.loads(project_response.data)
-        self.assertEqual(len(project_response['objects']), 1)
-        self.assertEqual(project_response['objects'][0]['type'], 'data portal')
-
-        org_project_response = self.app.get('/api/organizations/Code-for-San-Francisco/projects?q=portal')
-        org_project_response = json.loads(org_project_response.data)
-        self.assertEqual(len(org_project_response['objects']), 1)
-        self.assertEqual(org_project_response['objects'][0]['type'], 'data portal')
-
-    def test_project_search_includes_categories(self):
-        ''' The categories field is included in search results from the project and org/project endpoints
-        '''
-        organization = OrganizationFactory(name=u"Code for San Francisco")
-        ProjectFactory(organization_name=organization.name, categories=u'project management, civic hacking')
-        ProjectFactory(organization_name=organization.name, categories=u'animal control, twitter')
-        db.session.commit()
-        project_response = self.app.get('/api/projects?q=control')
-        project_response = json.loads(project_response.data)
-        self.assertEqual(len(project_response['objects']), 1)
-        self.assertEqual(project_response['objects'][0]['categories'], 'animal control, twitter')
-
-        org_project_response = self.app.get('/api/organizations/Code-for-San-Francisco/projects?q=control')
-        org_project_response = json.loads(org_project_response.data)
-        self.assertEqual(len(org_project_response['objects']), 1)
-        self.assertEqual(org_project_response['objects'][0]['categories'], 'animal control, twitter')
 
     def test_project_search_includes_tags(self):
         """
@@ -433,22 +400,6 @@ class TestProjects(IntegrationTest):
         self.assertEqual(len(org_project_response['objects']), 1)
         self.assertEqual(org_project_response['objects'][0]['tags'], 'food stamps, health')
 
-    def test_project_search_includes_github_details(self):
-        ''' The github_details field is included in search results from the project and org/project endpoints
-        '''
-        organization = OrganizationFactory(name=u"Code for San Francisco")
-        ProjectFactory(organization_name=organization.name, github_details=json.dumps({'panic': 'disco'}))
-        ProjectFactory(organization_name=organization.name, github_details=json.dumps({'button': 'red'}))
-        db.session.commit()
-        project_response = self.app.get('/api/projects?q=disco')
-        project_response = json.loads(project_response.data)
-        self.assertEqual(len(project_response['objects']), 1)
-        self.assertEqual(project_response['objects'][0]['github_details'], '{"panic": "disco"}')
-
-        org_project_response = self.app.get('/api/organizations/Code-for-San-Francisco/projects?q=disco')
-        org_project_response = json.loads(org_project_response.data)
-        self.assertEqual(len(org_project_response['objects']), 1)
-        self.assertEqual(org_project_response['objects'][0]['github_details'], '{"panic": "disco"}')
 
     def test_project_query_filter(self):
         '''


### PR DESCRIPTION
Both simplifies and improves the project search process.

It simplifies by removing `github_details` from the search text. We added it to get the programming language column, but it also added a ton of junk to the search column. We've removed all of that.

It improves by adding a ranking to where the search term came from. The `status` and `tags` columns have a higher ranking than the `name` and `description` columns.

WIP until we add tests.