### PR TITLE
Correct Failures with Github project paths ending with slashes #235

### DIFF
--- a/run_update.py
+++ b/run_update.py
@@ -368,6 +368,7 @@ def update_project_info(project):
 
     # Get the Github attributes
     if host == 'github.com':
+        path = sub(r"[\ /]+\s*$","",path)
         repo_url = GITHUB_REPOS_API_URL.format(repo_path=path)
 
         # If we've hit the GitHub rate limit, skip updating projects.


### PR DESCRIPTION
Fixes issue #235 by removing trailing slashes (and whitespace) from path variable before passing to github api functions.

The github api does not appear to like endpoints which still have slashes for several calls. The urlparse function will return path's including trailing whitespace or slashes if there are no other ascii characters following them. To avoid this mismatch this patch strips the slashes and spaces before passing them to the formatting function.