### PR TITLE
Issue 245 Use GitHub pushed_at or updated_at for Project last_updated

### DIFF
--- a/run_update_test.py
+++ b/run_update_test.py
@@ -652,6 +652,26 @@ class RunUpdateTestCase(unittest.TestCase):
             self.assertEqual(projects[1].last_updated, one_second_ago.strftime("%a, %d %b %Y %H:%M:%S %Z"))
 
 
+    def test_github_latest_update_time(self):
+        import run_update
+        import dateutil.parser
+        # Test that latest date is given
+        newer_time_from_github = u'2015-10-02T15:43:21Z'
+        older_time_from_github = u'2015-10-02T15:43:20Z'
+        github_details = {'pushed_at': newer_time_from_github, 'updated_at': older_time_from_github}
+        self.assertEqual(run_update.github_latest_update_time(github_details), dateutil.parser.parse(newer_time_from_github).strftime('%a, %d %b %Y %H:%M:%S %Z'))
+
+        #Test handling of missing data
+        github_details = {'updated_at': older_time_from_github}
+        self.assertEqual(run_update.github_latest_update_time(github_details), dateutil.parser.parse(older_time_from_github).strftime('%a, %d %b %Y %H:%M:%S %Z'))
+
+        github_details = {'pushed_at': newer_time_from_github}
+        self.assertEqual(run_update.github_latest_update_time(github_details), dateutil.parser.parse(newer_time_from_github).strftime('%a, %d %b %Y %H:%M:%S %Z'))
+
+        github_details = {}
+        self.assertIsNotNone(run_update.github_latest_update_time(github_details))
+
+
     def test_utf8_noncode_projects(self):
         ''' Test that utf8 project descriptions match exisiting projects.
         '''


### PR DESCRIPTION
Use the most recent of pushed_at or updated_at from GitHub details to set the project's last_updated.  
If one of these is missing it uses the other.  
If both are missing it uses current time and logs an error.  

The error is logged when the unit tests are run - is this OK?

$ python run_update_test.py 
./home/rdog/cfapi/.venv/lib/python2.7/site-packages/sqlalchemy/engine/default.py:574: SAWarning: Unicode type received non-unicode bind param value.
  processors[key](compiled_params[key])
......ERROR:run_update:GitHub Project details has neither pushed_at or updated_at, using current time.
................................
----------------------------------------------------------------------
Ran 39 tests in 30.312s

OK
