### PR TITLE
Speed up issues requests

### DIFF
--- a/app.py
+++ b/app.py
@@ -134,19 +134,23 @@ def paged_results_old(query, page, per_page, querystring=''):
 def paged_results(query, page=1, per_page=10, querystring=''):
     '''
     '''
-    # import pdb; pdb.set_trace()
     items = [item for item in query]
+    total = len(items)
     jsonify_us = dict(items=[])
     return_dict = dict(dictified=0, jsonified=0)
+    howmany = 5
+    if 'howmany' in querystring:
+        howmany = int(request.args['howmany'])
+    if howmany > total:
+        howmany = total
     if 'dictify' in querystring:
-        for check in range(0, 5):
+        for check in range(0, howmany):
             jsonify_us['items'].append(items[check].asdict(True))
         return_dict['dictified'] = check + 1
     if 'jsonify' in querystring:
         jsonify(jsonify_us)
         return_dict['jsonified'] = check + 1
     return return_dict
-    total = len(items)
     last, offset = page_info(total, page, per_page)
     page_of_items = items[offset:offset + per_page]
     if(querystring.find("only_ids") != -1):

--- a/app.py
+++ b/app.py
@@ -137,10 +137,15 @@ def paged_results(query, page=1, per_page=10, querystring=''):
     # import pdb; pdb.set_trace()
     items = [item for item in query]
     jsonify_us = dict(items=[])
-    for check in range(0, 5):
-        jsonify_us['items'].append(items[check].asdict(True))
-    jsonify(jsonify_us)
-    return dict(dictified=check + 1, jsonified=check + 1)
+    return_dict = dict(dictified=0, jsonified=0)
+    if 'dictify' in querystring:
+        for check in range(0, 5):
+            jsonify_us['items'].append(items[check].asdict(True))
+        return_dict['dictified'] = check + 1
+    if 'jsonify' in querystring:
+        jsonify(jsonify_us)
+        return_dict['jsonified'] = check + 1
+    return return_dict
     total = len(items)
     last, offset = page_info(total, page, per_page)
     page_of_items = items[offset:offset + per_page]
@@ -407,7 +412,8 @@ def get_orgs_issues_new(organization_name, labels=None):
     # run the query
     matches = Issue.query.from_statement(sql.text(issues_query))
 
-    response = paged_results(query=matches, page=int(request.args.get('page', 1)), per_page=int(request.args.get('per_page', 10)))
+    filters, querystring = get_query_params(request.args)
+    response = paged_results(query=matches, page=int(request.args.get('page', 1)), per_page=int(request.args.get('per_page', 10)), querystring=querystring)
     return jsonify(response)
 
 @app.route("/api/organizations_old/<organization_name>/issues")
@@ -448,7 +454,8 @@ def get_orgs_issues(organization_name, labels=None):
         # Get all issues belonging to these projects
         query = Issue.query.filter(Issue.project_id.in_(project_ids)).order_by(func.random())
 
-    response = paged_results(query=query, page=int(request.args.get('page', 1)), per_page=int(request.args.get('per_page', 10)))
+    filters, querystring = get_query_params(request.args)
+    response = paged_results(query=query, page=int(request.args.get('page', 1)), per_page=int(request.args.get('per_page', 10)), querystring=querystring)
     return jsonify(response)
 
 
@@ -690,7 +697,8 @@ def get_issues_by_labels_new(labels):
     # run the query
     matches = Issue.query.from_statement(sql.text(issues_query))
 
-    response = paged_results(query=matches, page=int(request.args.get('page', 1)), per_page=int(request.args.get('per_page', 10)))
+    filters, querystring = get_query_params(request.args)
+    response = paged_results(query=matches, page=int(request.args.get('page', 1)), per_page=int(request.args.get('per_page', 10)), querystring=querystring)
     return jsonify(response)
 
 @app.route('/api/issues_old/labels/<labels>')
@@ -727,7 +735,8 @@ def get_issues_by_labels(labels):
     query = base_query.intersect(*label_queries).order_by(func.random())
 
     # Return the paginated reponse
-    response = paged_results(query=query, page=int(request.args.get('page', 1)), per_page=int(request.args.get('per_page', 10)))
+    filters, querystring = get_query_params(request.args)
+    response = paged_results(query=query, page=int(request.args.get('page', 1)), per_page=int(request.args.get('per_page', 10)), querystring=querystring)
     return jsonify(response)
 
 

--- a/app.py
+++ b/app.py
@@ -134,8 +134,11 @@ def paged_results_old(query, page, per_page, querystring=''):
 def paged_results(query, page=1, per_page=10, querystring=''):
     '''
     '''
-    return dict(hello=u'world')
+    # import pdb; pdb.set_trace()
     items = [item for item in query]
+    for check in range(0, 5):
+        items[check].asdict(True)
+    return dict(converted=check + 1)
     total = len(items)
     last, offset = page_info(total, page, per_page)
     page_of_items = items[offset:offset + per_page]

--- a/app.py
+++ b/app.py
@@ -730,7 +730,11 @@ def get_issues_by_labels(labels):
             org_attr = attr.split('_')[1]
             base_query = base_query.join(Issue.project).join(Project.organization).filter(getattr(Organization, org_attr).ilike('%%%s%%' % value))
         else:
-            base_query = base_query.filter(getattr(Issue, attr).ilike('%%%s%%' % value))
+            try:
+                filter_attr = getattr(Issue, attr)
+                base_query = base_query.filter(filter_attr.ilike('%%%s%%' % value))
+            except AttributeError:
+                pass
 
     # Filter for issues with each individual label
     label_queries = [base_query.filter(L) for L in labels]

--- a/app.py
+++ b/app.py
@@ -75,11 +75,9 @@ app.after_request(add_cors_header)
 # API
 # -------------------
 
-def page_info(query, page, limit):
-    ''' Return last page and offset for a query.
+def page_info(total, page, limit):
+    ''' Return last page and offset for a query total.
     '''
-    # Get a bunch of projects.
-    total = query.count()
     last = int(ceil(total / limit))
     offset = (page - 1) * limit
 
@@ -123,7 +121,7 @@ def paged_results(query, page, per_page, querystring=''):
     '''
     '''
     total = query.count()
-    last, offset = page_info(query, page, per_page)
+    last, offset = page_info(total, page, per_page)
     if querystring.find("only_ids") != -1:
         model_dicts = [o.id for o in query.limit(per_page).offset(offset)]
     else:

--- a/app.py
+++ b/app.py
@@ -136,9 +136,11 @@ def paged_results(query, page=1, per_page=10, querystring=''):
     '''
     # import pdb; pdb.set_trace()
     items = [item for item in query]
+    jsonify_us = dict(items=[])
     for check in range(0, 5):
-        items[check].asdict(True)
-    return dict(converted=check + 1)
+        jsonify_us['items'].append(items[check].asdict(True))
+    jsonify(jsonify_us)
+    return dict(dictified=check + 1, jsonified=check + 1)
     total = len(items)
     last, offset = page_info(total, page, per_page)
     page_of_items = items[offset:offset + per_page]

--- a/app.py
+++ b/app.py
@@ -418,19 +418,20 @@ def get_orgs_issues_new(organization_name, labels=None):
     issues_query = u'''{query} GROUP BY issue.id ORDER BY random() LIMIT {limit};'''.format(query=issues_query, limit=per_page)
     # run the query
     issues_result = db.session.execute(issues_query)
+
     # issues_result is a ResultProxy object
     # http://docs.sqlalchemy.org/en/rel_1_0/core/connections.html#sqlalchemy.engine.ResultProxy
     issues_dicts = []
     for row in issues_result:
         # each row is a RowProxy object
         # http://docs.sqlalchemy.org/en/rel_1_0/core/connections.html#sqlalchemy.engine.RowProxy
-        issues_dicts.append(get_issue_dict_from_rowproxy(row))
+        issues_dicts.append(make_issue_dict_from_rowproxy(row))
 
     response = dict(objects=issues_dicts)
 
     return jsonify(response)
 
-def get_issue_dict_from_rowproxy(issue_row):
+def make_issue_dict_from_rowproxy(issue_row):
     ''' Take a RowProxy object representing an issue and return a complete dict of the issue.
     '''
     # start with a dict of the issue row

--- a/app.py
+++ b/app.py
@@ -375,9 +375,8 @@ def get_orgs_projects(organization_name):
     response = paged_results(query=query, include_args=dict(include_organization=True, include_issues=True), page=int(request.args.get('page', 1)), per_page=int(request.args.get('per_page', 10)), querystring=querystring)
     return jsonify(response)
 
-
-@app.route("/api/organizations/<organization_name>/issues")
-@app.route("/api/organizations/<organization_name>/issues/labels/<labels>")
+@app.route("/api/organizations_test/<organization_name>/issues")
+@app.route("/api/organizations_test/<organization_name>/issues/labels/<labels>")
 def get_orgs_issues_new(organization_name, labels=None):
     ''' Trying a raw SQL query instead
     '''
@@ -460,8 +459,8 @@ def make_issue_dict_from_rowproxy(issue_row):
 
     return issue_dict
 
-@app.route("/api/organizations_old/<organization_name>/issues")
-@app.route("/api/organizations_old/<organization_name>/issues/labels/<labels>")
+@app.route("/api/organizations/<organization_name>/issues")
+@app.route("/api/organizations/<organization_name>/issues/labels/<labels>")
 def get_orgs_issues(organization_name, labels=None):
     ''' A clean url to get an organizations issues
     '''
@@ -718,8 +717,7 @@ def get_issues(id=None):
     response = paged_results(query=query, include_args=dict(include_project=True, include_labels=True), page=int(request.args.get('page', 1)), per_page=int(request.args.get('per_page', 10)), querystring=querystring)
     return jsonify(response)
 
-
-@app.route('/api/issues/labels/<labels>')
+@app.route('/api/issues_test/labels/<labels>')
 def get_issues_by_labels_new(labels):
     '''
     A clean url to filter issues by a comma-separated list of labels
@@ -745,7 +743,7 @@ def get_issues_by_labels_new(labels):
     response = paged_results(query=matches, include_args=dict(include_project=True, include_labels=True), page=int(request.args.get('page', 1)), per_page=int(request.args.get('per_page', 10)), querystring=querystring)
     return jsonify(response)
 
-@app.route('/api/issues_old/labels/<labels>')
+@app.route('/api/issues/labels/<labels>')
 def get_issues_by_labels(labels):
     '''
     A clean url to filter issues by a comma-separated list of labels

--- a/app.py
+++ b/app.py
@@ -136,21 +136,23 @@ def paged_results(query, page=1, per_page=10, querystring=''):
     '''
     items = [item for item in query]
     total = len(items)
-    jsonify_us = dict(items=[])
-    return_dict = dict(dictified=0, jsonified=0)
-    howmany = 5
-    if 'howmany' in querystring:
-        howmany = int(request.args['howmany'])
-    if howmany > total:
-        howmany = total
-    if 'dictify' in querystring:
-        for check in range(0, howmany):
-            jsonify_us['items'].append(items[check].asdict(True))
-        return_dict['dictified'] = check + 1
-    if 'jsonify' in querystring:
-        jsonify(jsonify_us)
-        return_dict['jsonified'] = check + 1
-    return return_dict
+
+    # jsonify_us = dict(items=[])
+    # return_dict = dict(dictified=0, jsonified=0)
+    # howmany = 5
+    # if 'howmany' in querystring:
+    #     howmany = int(request.args['howmany'])
+    # if howmany > total:
+    #     howmany = total
+    # if 'dictify' in querystring:
+    #     for check in range(0, howmany):
+    #         jsonify_us['items'].append(items[check].asdict(True))
+    #     return_dict['dictified'] = check + 1
+    # if 'jsonify' in querystring:
+    #     jsonify(jsonify_us)
+    #     return_dict['jsonified'] = check + 1
+    # return return_dict
+
     last, offset = page_info(total, page, per_page)
     page_of_items = items[offset:offset + per_page]
     if(querystring.find("only_ids") != -1):

--- a/app.py
+++ b/app.py
@@ -134,6 +134,7 @@ def paged_results_old(query, page, per_page, querystring=''):
 def paged_results(query, page=1, per_page=10, querystring=''):
     '''
     '''
+    return dict(hello=u'world')
     items = [item for item in query]
     total = len(items)
     last, offset = page_info(total, page, per_page)

--- a/app.py
+++ b/app.py
@@ -23,9 +23,12 @@ from dictalchemy import make_class_dictable
 from flask.ext.script import Manager, prompt_bool
 from flask.ext.migrate import Migrate, MigrateCommand
 from werkzeug.contrib.fixers import ProxyFix
-
 from models import initialize_database, Organization, Event, Issue, Project, Story, Label, Error, Attendance
 from utils import raw_name
+
+# import logging
+# logging.basicConfig()
+# logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
 
 # -------------------
 # Init

--- a/models.py
+++ b/models.py
@@ -55,7 +55,6 @@ class JsonType(Mutable, types.TypeDecorator):
             # default can also be a list
             return {}
 
-
 class TSVectorType(types.TypeDecorator):
     ''' TSVECTOR wrapper type for database storage.
 
@@ -63,7 +62,6 @@ class TSVectorType(types.TypeDecorator):
         http://stackoverflow.com/questions/13837111/tsvector-in-sqlalchemy
     '''
     impl = types.UnicodeText
-
 
 @compiles(TSVectorType, 'postgresql')
 def compile_tsvector(element, compiler, **kw):
@@ -356,7 +354,7 @@ class Project(db.Model):
             project_dict['organization'] = self.organization.asdict()
 
         if include_issues:
-            project_dict['issues'] = [o.asdict() for o in db.session.query(Issue).filter(Issue.project_id == project_dict['id']).all()]
+            project_dict['issues'] = [o.asdict(include_project=False, include_labels=True) for o in db.session.query(Issue).filter(Issue.project_id == project_dict['id']).all()]
 
         return project_dict
 
@@ -550,11 +548,12 @@ class Event(db.Model):
         for key in ('keep', 'start_time_notz', 'end_time_notz', 'utc_offset'):
             del event_dict[key]
 
+        # add custom fields not in database
         for key in ('start_time', 'end_time', 'api_url'):
             event_dict[key] = getattr(self, key)()
 
         if include_organization:
-            event_dict['organization'] = self.organization.asdict()
+            event_dict['organization'] = self.organization.asdict(include_extras=False)
 
         return event_dict
 

--- a/run_update.py
+++ b/run_update.py
@@ -1148,11 +1148,13 @@ def main(org_name=None, org_sources=None):
                 save_labels(db.session, issue)
 
             # Get attendance data
-            with connect(PEOPLEDB) as conn:
-                with conn.cursor(cursor_factory=extras.RealDictCursor) as peopledb:
-                    cfapi_url = "https://www.codeforamerica.org/api/organizations/"
-                    organization_url = cfapi_url + organization.api_id()
-                    attendance = get_attendance(peopledb, organization_url, organization.name)
+            attendance = None
+            if PEOPLEDB:
+                with connect(PEOPLEDB) as conn:
+                    with conn.cursor(cursor_factory=extras.RealDictCursor) as peopledb:
+                        cfapi_url = "https://www.codeforamerica.org/api/organizations/"
+                        organization_url = cfapi_url + organization.api_id()
+                        attendance = get_attendance(peopledb, organization_url, organization.name)
 
             if attendance:
                 update_attendance(db, organization.name, attendance)


### PR DESCRIPTION
Getting issues was slow because every issue was querying its project, which then queried its every issue. Then we were deleting the project's issues before we displayed it. So listing 10 issues on a project with 100 issues could generate 1,000 unneeded database calls.

I fixed this by telling the project not to request its issues, which makes the query 7-10x faster. I also made some changes for clarity along the way.

While I was researching the issue I experimented with a couple different approaches to replacing the sqlalchemy calls with raw SQL, and found that they weren't appreciably faster (less than a tenth of a second faster on average).

Closes #230 
Closes #231 
