### PR TITLE
Handle secondary GitHub URLs

### DIFF
--- a/run_update.py
+++ b/run_update.py
@@ -374,6 +374,14 @@ def non_github_project_update_time(project):
     return project
 
 
+def make_root_github_project_path(path):
+    ''' Strip anything extra off the end of a github path
+    '''
+    path_split = path.split('/')
+    path = '/'.join(path_split[0:3])
+    return path
+
+
 def update_project_info(project):
     ''' Update info from Github, if it's missing.
 
@@ -398,6 +406,8 @@ def update_project_info(project):
     # Get the Github attributes
     if host == 'github.com':
         path = sub(r"[\s\/]+?$", "", path)
+        # make sure we're working with the main github URL
+        path = make_root_github_project_path(path)
         repo_url = GITHUB_REPOS_API_URL.format(repo_path=path)
 
         # If we've hit the GitHub rate limit, skip updating projects.
@@ -631,6 +641,8 @@ def get_issues_for_project(project):
     # Get github issues api url
     _, host, path, _, _, _ = urlparse(project.code_url)
     path = sub(r"[\s\/]+?$", "", path)
+    # make sure we're working with the main github URL
+    path = make_root_github_project_path(path)
     issues_url = GITHUB_ISSUES_API_URL.format(repo_path=path)
 
     # Ping github's api for project issues
@@ -681,6 +693,8 @@ def get_issues(org_name):
             continue
 
         path = sub(r"[\s\/]+?$", "", path)
+        # make sure we're working with the main github URL
+        path = make_root_github_project_path(path)
         issues_url = GITHUB_ISSUES_API_URL.format(repo_path=path)
 
         # Ping github's api for project issues
@@ -729,6 +743,8 @@ def get_root_directory_listing_for_project(project_dict, force=False):
     # Get the API URL
     _, host, path, _, _, _ = urlparse(project_dict['code_url'])
     path = sub(r"[\s\/]+?$", "", path)
+    # make sure we're working with the main github URL
+    path = make_root_github_project_path(path)
     directory_url = GITHUB_CONTENT_API_URL.format(repo_path=path, file_path='')
 
     # Request the directory listing
@@ -774,6 +790,8 @@ def get_civic_json_for_project(project_dict, force=False):
     # Get the API URL (if 'code_url' wasn't in project_dict, it would've been caught upstream)
     _, host, path, _, _, _ = urlparse(project_dict['code_url'])
     path = sub(r"[\s\/]+?$", "", path)
+    # make sure we're working with the main github URL
+    path = make_root_github_project_path(path)
     civic_url = GITHUB_CONTENT_API_URL.format(repo_path=path, file_path='civic.json')
 
     # Request the contents of the civic.json file

--- a/run_update.py
+++ b/run_update.py
@@ -397,7 +397,7 @@ def update_project_info(project):
 
     # Get the Github attributes
     if host == 'github.com':
-        path = sub(r"[\ /]+\s*$", "", path)
+        path = sub(r"[\s\/]+?$", "", path)
         repo_url = GITHUB_REPOS_API_URL.format(repo_path=path)
 
         # If we've hit the GitHub rate limit, skip updating projects.
@@ -630,7 +630,7 @@ def get_issues_for_project(project):
 
     # Get github issues api url
     _, host, path, _, _, _ = urlparse(project.code_url)
-    path = sub(r"[\ /]+\s*$", "", path)
+    path = sub(r"[\s\/]+?$", "", path)
     issues_url = GITHUB_ISSUES_API_URL.format(repo_path=path)
 
     # Ping github's api for project issues
@@ -680,7 +680,7 @@ def get_issues(org_name):
         if host != 'github.com':
             continue
 
-        path = sub(r"[\ /]+\s*$", "", path)
+        path = sub(r"[\s\/]+?$", "", path)
         issues_url = GITHUB_ISSUES_API_URL.format(repo_path=path)
 
         # Ping github's api for project issues
@@ -728,7 +728,7 @@ def get_root_directory_listing_for_project(project_dict, force=False):
 
     # Get the API URL
     _, host, path, _, _, _ = urlparse(project_dict['code_url'])
-    path = sub(r"[\ /]+\s*$", "", path)
+    path = sub(r"[\s\/]+?$", "", path)
     directory_url = GITHUB_CONTENT_API_URL.format(repo_path=path, file_path='')
 
     # Request the directory listing
@@ -773,7 +773,7 @@ def get_civic_json_for_project(project_dict, force=False):
 
     # Get the API URL (if 'code_url' wasn't in project_dict, it would've been caught upstream)
     _, host, path, _, _, _ = urlparse(project_dict['code_url'])
-    path = sub(r"[\ /]+\s*$", "", path)
+    path = sub(r"[\s\/]+?$", "", path)
     civic_url = GITHUB_CONTENT_API_URL.format(repo_path=path, file_path='civic.json')
 
     # Request the contents of the civic.json file

--- a/test/updater/test_run_update.py
+++ b/test/updater/test_run_update.py
@@ -1229,6 +1229,44 @@ class RunUpdateTestCase(unittest.TestCase):
         from app import Event
         self.assertEqual(self.db.session.query(Event).count(), 0)
 
+    def test_secondary_github_urls_handled_correctly(self):
+        ''' Projects with secondary GitHub URLs as their main URL are handled correctly.
+        '''
+        self.setup_mock_rss_response()
+
+        from app import Project
+        import run_update
+
+        # alter responses to return only one organization, with one project that
+        # has a 2nd-level GitHub URL (with /issues at the end)
+        def overwrite_response_content(url, request):
+            if "docs.google.com" in url:
+                org_lines = [u'''name,website,events_url,rss,projects_list_url'''.encode('utf8'), u'''Cöde for Ameriça,http://codeforamerica.org,http://www.meetup.com/events/Code-For-Charlotte/,http://www.codeforamerica.org/blog/feed/,http://example.com/cfa-projects.csv'''.encode('utf8')]
+                return response(200, '''\n'''.join(org_lines), {'content-type': 'text/csv; charset=UTF-8'})
+            elif url.geturl() == 'http://example.com/cfa-projects.csv':
+                project_lines = ['''Name,description,link_url,code_url,type,categories,tags,status'''.encode('utf8'), ''',,,https://github.com/codeforamerica/cityvoice/issues,,,"safety, police, poverty",Shuttered'''.encode('utf8')]
+                return response(200, '''\n'''.join(project_lines), {'content-type': 'text/csv; charset=UTF-8'})
+
+        # run a standard run_update
+        with HTTMock(self.response_content):
+            with HTTMock(overwrite_response_content):
+                run_update.main(org_sources=run_update.TEST_ORG_SOURCES_FILENAME)
+
+        check_project = self.db.session.query(Project).first()
+        # the project exists
+        self.assertIsNotNone(check_project)
+        self.assertIsNotNone(check_project.id)
+        # the project has issues
+        self.assertTrue(hasattr(check_project, 'issues'))
+        self.assertTrue(len(check_project.issues) > 0)
+        # the project has status & tags from civic.json
+        self.assertTrue(check_project.status is not None)
+        self.assertTrue(type(check_project.status) is unicode)
+        self.assertTrue(len(check_project.status) > 0)
+        self.assertTrue(check_project.tags is not None)
+        self.assertTrue(type(check_project.tags) is unicode)
+        self.assertTrue(len(check_project.tags) > 0)
+
     def test_unmodified_projects_stay_in_database(self):
         ''' Verify that unmodified projects are not deleted from the database
         '''


### PR DESCRIPTION
The API can now handle a lower-level GitHub URL like `codeforamerica/cfapi/issues` or `codeforamerica/cfapi/wiki` passed as the code URL. It handles it by stripping anything after the project in the URL before it uses it to query the GitHub API.

Closes #261
