### PR TITLE
Improve memory handling during update

### DIFF
--- a/app.py
+++ b/app.py
@@ -793,26 +793,24 @@ def well_known_status():
 
         http://engine-light.codeforamerica.org
     '''
+    GITHUB_AUTH = None
     if 'GITHUB_TOKEN' in os.environ:
-        github_auth = (os.environ['GITHUB_TOKEN'], '')
-    else:
-        github_auth = None
+        GITHUB_AUTH = (os.environ['GITHUB_TOKEN'], '')
 
+    MEETUP_KEY = None
     if 'MEETUP_KEY' in os.environ:
-        meetup_key = os.environ['MEETUP_KEY']
-    else:
-        meetup_key = None
+        MEETUP_KEY = os.environ['MEETUP_KEY']
 
     try:
         org = db.session.query(Organization).order_by(Organization.last_updated).limit(1).first()
         project = db.session.query(Project).limit(1).first()
-        rate_limit = requests.get('https://api.github.com/rate_limit', auth=github_auth)
+        rate_limit = requests.get('https://api.github.com/rate_limit', auth=GITHUB_AUTH)
         remaining_github = rate_limit.json()['resources']['core']['remaining']
         recent_error = db.session.query(Error).order_by(desc(Error.time)).limit(1).first()
 
         meetup_status = "No Meetup key set"
-        if meetup_key:
-            meetup_url = 'https://api.meetup.com/status?format=json&key=' + meetup_key
+        if MEETUP_KEY:
+            meetup_url = 'https://api.meetup.com/status?format=json&key=' + MEETUP_KEY
             meetup_status = requests.get(meetup_url).json().get('status')
 
         time_since_updated = time.time() - getattr(org, 'last_updated', -1)

--- a/run_update.py
+++ b/run_update.py
@@ -977,8 +977,8 @@ def save_issue_info(session, issue_dict):
 
         Return an app.Issue instance
     '''
-    # Select the current issue, filtering on title and project_id.
-    filter = Issue.title == issue_dict['title'], Issue.project_id == issue_dict['project_id']
+    # Select the current issue, filtering on html_url and project id.
+    filter = Issue.html_url == issue_dict['html_url'], Issue.project_id == issue_dict['project_id']
     existing_issue = session.query(Issue).filter(*filter).first()
 
     # If this is a new issue save and return it.
@@ -1002,8 +1002,8 @@ def save_issue_info(session, issue_dict):
 def save_labels_info(session, issue_dict):
     ''' Save labels to issues
     '''
-    # Select the current issue, filtering on title AND project_id.
-    filter = Issue.title == issue_dict['title'], Issue.project_id == issue_dict['project_id']
+    # Select the current issue, filtering on html_url and project id.
+    filter = Issue.html_url == issue_dict['html_url'], Issue.project_id == issue_dict['project_id']
     existing_issue = session.query(Issue).filter(*filter).first()
 
     # Get list of existing and incoming label names (dupes will be filtered out in comparison process)
@@ -1031,8 +1031,7 @@ def save_event_info(session, event_dict):
         that event instance
     '''
     # Select the current event, filtering on event_url and organization name.
-    filter = Event.event_url == event_dict['event_url'], \
-        Event.organization_name == event_dict['organization_name']
+    filter = Event.event_url == event_dict['event_url'], Event.organization_name == event_dict['organization_name']
     existing_event = session.query(Event).filter(*filter).first()
 
     # If this is a new event, save and return it.
@@ -1058,8 +1057,7 @@ def save_story_info(session, story_dict):
         that story instance
     '''
     # Select the current story, filtering on link and organization name.
-    filter = Story.organization_name == story_dict['organization_name'], \
-        Story.link == story_dict['link']
+    filter = Story.organization_name == story_dict['organization_name'], Story.link == story_dict['link']
 
     existing_story = session.query(Story).filter(*filter).first()
 

--- a/run_update.py
+++ b/run_update.py
@@ -123,7 +123,7 @@ def get_meetup_events(organization, group_urlname):
 
     got = get(meetup_url)
     if got.status_code in range(400, 499):
-        logging.error("%s's meetup page cannot be found" % organization.name)
+        logging.error("{}'s meetup page cannot be found".format(organization.name))
         return events
     else:
         try:
@@ -768,6 +768,7 @@ def get_issues(project):
                 issues.append(issue_dict)
             else:
                 logging.error('Issue for project %s is not a dictionary', project.name)
+
     return issues
 
 
@@ -1166,13 +1167,12 @@ def main(org_name=None, org_sources=None):
     if org_name:
         orgs_info = [org for org in orgs_info if org['name'] == org_name]
 
-
-    # Retreive and save all information about the organizations
+    # Retrieve and save all information about the organizations
     for org_info in orgs_info:
 
         if not is_safe_name(org_info['name']):
             error_dict = {
-                "error": unicode('ValueError: Bad organization name: "%s"' % org_info['name']),
+                "error": unicode('ValueError: Bad organization name: "{}"'.format(org_info['name'])),
                 "time": datetime.now()
             }
             new_error = Error(**error_dict)
@@ -1198,7 +1198,7 @@ def main(org_name=None, org_sources=None):
 
             # STORIES
             if organization.rss or organization.website:
-                logging.info("Gathering all of %s's stories." % organization.name)
+                logging.info("Gathering all of {}'s stories.".format(organization.name))
                 stories = get_stories(organization)
                 # build and commit stories
                 for story_info in stories:
@@ -1207,7 +1207,7 @@ def main(org_name=None, org_sources=None):
 
             # PROJECTS, ISSUES and LABELS
             if organization.projects_list_url:
-                logging.info("Gathering all of %s's projects." % organization.name)
+                logging.info("Gathering all of {}'s projects.".format(organization.name))
                 projects = get_projects(organization)
                 # build and commit projects
                 for proj_dict in projects:
@@ -1225,7 +1225,7 @@ def main(org_name=None, org_sources=None):
 
             # EVENTS
             if organization.events_url:
-                logging.info("Gathering all of %s's events." % organization.name)
+                logging.info("Gathering all of {}'s events.".format(organization.name))
                 identifier = get_event_group_identifier(organization.events_url)
                 if identifier:
                     # build and commit events
@@ -1241,7 +1241,7 @@ def main(org_name=None, org_sources=None):
                         db.session.commit()
 
                 else:
-                    logging.error("%s does not have a valid events url" % organization.name)
+                    logging.error("{} does not have a valid events url".format(organization.name))
 
             # ATTENDANCE
             attendance = None

--- a/run_update.py
+++ b/run_update.py
@@ -65,7 +65,7 @@ def get_github_api(url, headers=None):
         Make authenticated GitHub requests.
     '''
     global GITHUB_THROTTLING
-    logging.info('Asking Github for {}{}'.format(url, ' ({})'.format(headers) if headers and headers != {} else ''))
+    logging.info(u'Asking Github for {}{}'.format(url, u' ({})'.format(headers) if headers and headers != {} else u''))
 
     got = get(url, auth=GITHUB_AUTH, headers=headers)
 
@@ -105,9 +105,9 @@ def format_location(venue):
         address = address + ', ' + venue['address_2']
 
     if 'state' in venue:
-        return "{address}, {city}, {state}, {country}".format(address=address, city=venue['city'], state=venue['state'], country=venue['country'])
+        return u'{address}, {city}, {state}, {country}'.format(address=address, city=venue['city'], state=venue['state'], country=venue['country'])
     else:
-        return "{address}, {city}, {country}".format(address=address, city=venue['city'], country=venue['country'])
+        return u'{address}, {city}, {country}'.format(address=address, city=venue['city'], country=venue['country'])
 
 
 def get_meetup_events(organization, group_urlname):
@@ -123,7 +123,7 @@ def get_meetup_events(organization, group_urlname):
 
     got = get(meetup_url)
     if got.status_code in range(400, 499):
-        logging.error("{}'s meetup page cannot be found".format(organization.name))
+        logging.error(u"{}'s meetup page cannot be found".format(organization.name))
         return events
     else:
         try:
@@ -510,7 +510,7 @@ def update_project_info(project):
 
         # If the project has not been modified...
         elif got.status_code == 304:
-            logging.info('Project {} has not been modified since last update'.format(repo_url))
+            logging.info(u'Project {} has not been modified since last update'.format(repo_url))
 
             # Populate values from the civic.json if it exists/is updated
             project, civic_json_is_updated = update_project_from_civic_json(project_dict=project, force=spreadsheet_is_updated)
@@ -797,17 +797,17 @@ def get_root_directory_listing_for_project(project_dict, force=False):
 
     # Verify that content has not been modified since last run
     if got.status_code == 304:
-        logging.info('root directory listing has not changed since last update for {}'.format(directory_url))
+        logging.info(u'root directory listing has not changed since last update for {}'.format(directory_url))
 
     elif got.status_code not in range(400, 499):
-        logging.info('root directory listing has changed for {}'.format(directory_url))
+        logging.info(u'root directory listing has changed for {}'.format(directory_url))
         # Update the project's last_updated_root_files field
         project_dict['last_updated_root_files'] = unicode(got.headers['ETag'])
         # get the contents of the file
         listing = got.json()
 
     else:
-        logging.info('NO root directory listing found for {}'.format(directory_url))
+        logging.info(u'NO root directory listing found for {}'.format(directory_url))
 
     return listing
 
@@ -846,20 +846,20 @@ def get_civic_json_for_project(project_dict, force=False):
 
     # Verify that content has not been modified since last run
     if got.status_code == 304:
-        logging.info('Unchanged civic.json at {}'.format(civic_url))
+        logging.info(u'Unchanged civic.json at {}'.format(civic_url))
 
     elif got.status_code not in range(400, 499):
-        logging.info('New civic.json at {}'.format(civic_url))
+        logging.info(u'New civic.json at {}'.format(civic_url))
         # Update the project's last_updated_civic_json field
         project_dict['last_updated_civic_json'] = unicode(got.headers['ETag'])
         try:
             # get the contents of the file
             civic = got.json()
         except ValueError:
-            logging.error('Malformed civic.json at {}'.format(civic_url))
+            logging.error(u'Malformed civic.json at {}'.format(civic_url))
 
     else:
-        logging.info('No civic.json at {}'.format(civic_url))
+        logging.info(u'No civic.json at {}'.format(civic_url))
 
     return civic
 
@@ -1198,7 +1198,7 @@ def main(org_name=None, org_sources=None):
 
             # STORIES
             if organization.rss or organization.website:
-                logging.info("Gathering all of {}'s stories.".format(organization.name))
+                logging.info(u"Gathering all of {}'s stories.".format(organization.name))
                 stories = get_stories(organization)
                 # build and commit stories
                 for story_info in stories:
@@ -1207,14 +1207,14 @@ def main(org_name=None, org_sources=None):
 
             # PROJECTS, ISSUES and LABELS
             if organization.projects_list_url:
-                logging.info("Gathering all of {}'s projects.".format(organization.name))
+                logging.info(u"Gathering all of {}'s projects.".format(organization.name))
                 projects = get_projects(organization)
                 # build and commit projects
                 for proj_dict in projects:
                     saved_project = save_project_info(db.session, proj_dict)
                     db.session.commit()
 
-                    logging.info(u"Gathering all issues for this {} project: {}.".format(organization.name, saved_project.name))
+                    logging.info(u'Gathering all issues for this {} project: {}.'.format(organization.name, saved_project.name))
                     issues = get_issues(saved_project)
                     # build and commit issues and labels
                     for issue_dict in issues:
@@ -1225,7 +1225,7 @@ def main(org_name=None, org_sources=None):
 
             # EVENTS
             if organization.events_url:
-                logging.info("Gathering all of {}'s events.".format(organization.name))
+                logging.info(u"Gathering all of {}'s events.".format(organization.name))
                 identifier = get_event_group_identifier(organization.events_url)
                 if identifier:
                     # build and commit events
@@ -1241,7 +1241,7 @@ def main(org_name=None, org_sources=None):
                         db.session.commit()
 
                 else:
-                    logging.error("{} does not have a valid events url".format(organization.name))
+                    logging.error(u'{} does not have a valid events url'.format(organization.name))
 
             # ATTENDANCE
             attendance = None

--- a/run_update.py
+++ b/run_update.py
@@ -749,7 +749,8 @@ def get_issues(project):
         project.last_updated_issues = unicode(got.headers['ETag'])
         db.session.add(project)
 
-        responses, _ = get_adjoined_json_lists(got, headers={'If-None-Match': project.last_updated_issues})
+        # Get all the pages of issues
+        responses, _ = get_adjoined_json_lists(got)
 
         # Save each issue in response
         for issue in responses:

--- a/run_update.py
+++ b/run_update.py
@@ -912,19 +912,22 @@ def count_people_totals(all_projects):
     return users
 
 
-def save_organization_info(session, org_dict):
+def save_organization_info(session, org_info):
     ''' Save a dictionary of organization info to the datastore session.
 
         Return an app.Organization instance.
     '''
+    # Set any empty strings in org_info to None
+    org_info = {key: None if not value else value for (key, value) in org_info.iteritems()}
+
     # Select an existing organization by name.
-    filter = Organization.name == org_dict['name']
+    filter = Organization.name == org_info['name']
     existing_org = session.query(Organization).filter(filter).first()
 
     # :::here (organization/true)
     # If this is a new organization, save and return it. The keep parameter is True by default.
     if not existing_org:
-        new_organization = Organization(**org_dict)
+        new_organization = Organization(**org_info)
         session.add(new_organization)
         return new_organization
 
@@ -938,7 +941,7 @@ def save_organization_info(session, org_dict):
     existing_org.keep = True
 
     # Update existing organization details.
-    for (field, value) in org_dict.items():
+    for (field, value) in org_info.items():
         setattr(existing_org, field, value)
 
     return existing_org
@@ -1174,14 +1177,6 @@ def main(org_name=None, org_sources=None):
             db.session.execute(db.update(Organization, values={'keep': False}).where(Organization.name == org_info['name']))
             # commit the false keeps
             db.session.commit()
-
-            # Empty lat longs are okay.
-            if 'latitude' in org_info:
-                if not org_info['latitude']:
-                    org_info['latitude'] = None
-            if 'longitude' in org_info:
-                if not org_info['longitude']:
-                    org_info['longitude'] = None
 
             organization = save_organization_info(db.session, org_info)
 

--- a/run_update.py
+++ b/run_update.py
@@ -1266,9 +1266,13 @@ def main(org_name=None, org_sources=None):
 
 parser = ArgumentParser(description='''Update database from CSV source URL.''')
 parser.add_argument('--name', dest='name', help='Single organization name to update.')
-parser.add_argument('--test', action='store_const', dest='org_sources', const=TEST_ORG_SOURCES_FILENAME, help='Use the testing list of organizations.')
+parser.add_argument('--sources', dest='sources', help='URL of an organization sources CSV file.')
+parser.add_argument('--test', action='store_const', dest='test_sources', const=TEST_ORG_SOURCES_FILENAME, help='Use the testing list of organizations.')
 
 if __name__ == "__main__":
     args = parser.parse_args()
     org_name = args.name and args.name.decode('utf8') or ''
-    main(org_name=org_name, org_sources=args.org_sources)
+    org_sources = args.sources and args.sources.decode('utf8') or ''
+    if args.test_sources and not org_sources:
+        org_sources = args.test_sources
+    main(org_name=org_name, org_sources=org_sources)

--- a/test/updater/test_run_update.py
+++ b/test/updater/test_run_update.py
@@ -42,7 +42,7 @@ class RunUpdateTestCase(unittest.TestCase):
         self.db.create_all()
 
         import run_update
-        run_update.github_throttling = False
+        run_update.GITHUB_THROTTLING = False
 
         # FAKE PEOPLEDB
         with connect(os.environ["PEOPLEDB"]) as conn:
@@ -378,7 +378,7 @@ class RunUpdateTestCase(unittest.TestCase):
         with HTTMock(self.response_content):
             with HTTMock(overwrite_response_content):
                 import run_update
-                self.assertFalse(run_update.github_throttling)
+                self.assertFalse(run_update.GITHUB_THROTTLING)
                 with self.assertRaises(IOError):
                     run_update.main(org_sources=run_update.TEST_ORG_SOURCES_FILENAME)
 
@@ -1521,18 +1521,18 @@ class RunUpdateTestCase(unittest.TestCase):
 
         # Call a function to pull data out of it
         with connect(PEOPLEDB) as conn:
-            with conn.cursor(cursor_factory=extras.RealDictCursor) as peopledb:
+            with conn.cursor(cursor_factory=extras.RealDictCursor) as peopledb_cursor:
                 import run_update
                 from app import Attendance, Organization
                 from test.factories import OrganizationFactory
                 cfsf = OrganizationFactory(name='Code for San Francisco')
                 oakland = OrganizationFactory(name='Open Oakland')
 
-                cfsf_attendance = run_update.get_attendance(peopledb, cfsf_url, cfsf.name)
+                cfsf_attendance = run_update.get_attendance(peopledb_cursor, cfsf_url, cfsf.name)
                 self.assertEqual(cfsf_attendance["organization_name"], "Code for San Francisco")
                 self.assertTrue("2015 01" in cfsf_attendance["weekly"].keys())
 
-                oakland_attendance = run_update.get_attendance(peopledb, oakland_url, oakland.name)
+                oakland_attendance = run_update.get_attendance(peopledb_cursor, oakland_url, oakland.name)
                 self.assertEqual(oakland_attendance["organization_name"], "Open Oakland")
                 self.assertTrue("2015 03" in oakland_attendance["weekly"].keys())
 

--- a/test/updater/test_run_update.py
+++ b/test/updater/test_run_update.py
@@ -5,7 +5,6 @@ import unittest
 import datetime
 import logging
 import time
-import json
 from re import match, search, sub
 
 from httmock import response, HTTMock
@@ -355,7 +354,7 @@ class RunUpdateTestCase(unittest.TestCase):
         # Thu, 16 Jan 2014 19:00:00 -05:00
         self.assertEqual(first_event.utc_offset, -5 * 3600)
         self.assertEqual(first_event.start_time_notz, datetime.datetime(2014, 1, 16, 19, 0, 0))
-        self.assertEqual(first_event.name,u'Organizational meeting')
+        self.assertEqual(first_event.name, u'Organizational meeting')
 
         second_event = events.pop(0)
         # Thu, 20 Feb 2014 18:30:00 -05:00
@@ -631,7 +630,6 @@ class RunUpdateTestCase(unittest.TestCase):
             self.assertEqual(projects[0]['status'], "active")
             self.assertEqual(projects[0]['last_updated'], datetime.datetime.now().strftime("%a, %d %b %Y %H:%M:%S %Z"))
 
-
     def test_non_github_projects_same_name(self):
         ''' Test that non github projects with same name but different groups dont overlap
         '''
@@ -695,7 +693,7 @@ class RunUpdateTestCase(unittest.TestCase):
         github_details = {'pushed_at': newer_time_from_github, 'updated_at': older_time_from_github}
         self.assertEqual(run_update.github_latest_update_time(github_details), dateutil.parser.parse(newer_time_from_github).strftime('%a, %d %b %Y %H:%M:%S %Z'))
 
-        #Test handling of missing data
+        # Test handling of missing data
         github_details = {'updated_at': older_time_from_github}
         self.assertEqual(run_update.github_latest_update_time(github_details), dateutil.parser.parse(older_time_from_github).strftime('%a, %d %b %Y %H:%M:%S %Z'))
 
@@ -704,7 +702,6 @@ class RunUpdateTestCase(unittest.TestCase):
 
         github_details = {}
         self.assertIsNotNone(run_update.github_latest_update_time(github_details))
-
 
     def test_utf8_noncode_projects(self):
         ''' Test that utf8 project descriptions match exisiting projects.
@@ -1517,7 +1514,6 @@ class RunUpdateTestCase(unittest.TestCase):
 
         self.results_state = 'before'
 
-
     def test_attendance(self):
         ''' Test gathering attendance from the peopledb '''
         # Mock attendance data
@@ -1525,10 +1521,10 @@ class RunUpdateTestCase(unittest.TestCase):
         cfsf_name = "Code for San Francisco"
         oakland_url = "https://www.codeforamerica.org/api/organizations/Open-Oakland"
         oakland_name = "Open Oakland"
-        cfsf_checkin1 = datetime.datetime.strptime("2015-01-01","%Y-%m-%d")
-        cfsf_checkin2 = datetime.datetime.strptime("2015-01-08","%Y-%m-%d")
-        oakland_checkin1 = datetime.datetime.strptime("2015-01-16","%Y-%m-%d")
-        oakland_checkin2 = datetime.datetime.strptime("2015-01-24","%Y-%m-%d")
+        cfsf_checkin1 = datetime.datetime.strptime("2015-01-01", "%Y-%m-%d")
+        cfsf_checkin2 = datetime.datetime.strptime("2015-01-08", "%Y-%m-%d")
+        oakland_checkin1 = datetime.datetime.strptime("2015-01-16", "%Y-%m-%d")
+        oakland_checkin2 = datetime.datetime.strptime("2015-01-24", "%Y-%m-%d")
 
         # Access the peopledb
         PEOPLEDB = 'postgres:///peopledbtest'
@@ -1548,27 +1544,26 @@ class RunUpdateTestCase(unittest.TestCase):
         with connect(PEOPLEDB) as conn:
             with conn.cursor(cursor_factory=extras.RealDictCursor) as peopledb_cursor:
                 import run_update
-                from app import Attendance, Organization
+                from app import Attendance
                 from test.factories import OrganizationFactory
                 cfsf = OrganizationFactory(name='Code for San Francisco')
                 oakland = OrganizationFactory(name='Open Oakland')
 
                 cfsf_attendance = run_update.get_attendance(peopledb_cursor, cfsf_url, cfsf.name)
-                self.assertEqual(cfsf_attendance["organization_name"], "Code for San Francisco")
+                self.assertEqual(cfsf_attendance["organization_name"], cfsf_name)
                 self.assertTrue("2015 01" in cfsf_attendance["weekly"].keys())
 
                 oakland_attendance = run_update.get_attendance(peopledb_cursor, oakland_url, oakland.name)
-                self.assertEqual(oakland_attendance["organization_name"], "Open Oakland")
+                self.assertEqual(oakland_attendance["organization_name"], oakland_name)
                 self.assertTrue("2015 03" in oakland_attendance["weekly"].keys())
 
         run_update.update_attendance(self.db.session, cfsf.name, cfsf_attendance)
         run_update.update_attendance(self.db.session, oakland.name, oakland_attendance)
         self.db.session.commit()
         attendance = self.db.session.query(Attendance).all()
-        self.assertEqual(attendance[0].organization_name, "Code for San Francisco")
-        self.assertEqual(attendance[1].organization_name, "Open Oakland")
+        self.assertEqual(attendance[0].organization_name, cfsf_name)
+        self.assertEqual(attendance[1].organization_name, oakland_name)
         self.assertTrue("2015 03" in attendance[1].weekly.keys())
-
 
     def test_meetup_count(self):
         ''' Test getting membership count from Meetup
@@ -1580,7 +1575,6 @@ class RunUpdateTestCase(unittest.TestCase):
             org.member_count = run_update.get_meetup_count(organization=org, identifier="TEST-MEETUP")
 
         self.assertEqual(org.member_count, 100)
-
 
     def test_languages(self):
         ''' Test pulling languages from Github '''


### PR DESCRIPTION
Refactors the run_update loop, hoping to reduce memory usage by committing frequently during an organization's update process instead of just at the end. Also makes a lot of small changes to keep the process consistent and readable.

Fixes a bug where multiple issues on a project with the same name conflicted.

Closes #270