### PR TITLE
Improve update memory handling (part two)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: newrelic-admin run-program gunicorn -w 8 app:app
+web: newrelic-admin run-program gunicorn --workers 6 app:app

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ Flask-Restless==0.12.1
 Flask-Script==2.0.5
 Flask-SQLAlchemy==1.0
 green==1.11.0
-gunicorn==0.17.4
+gunicorn==19.3.0
 httmock==1.2.1
 itsdangerous==0.23
 Jinja2==2.7.2


### PR DESCRIPTION
I reduced the number of gunicorn workers from 8 to 6, and upgraded gunicorn to the most recent version available via pip. This appears to've fixed the memory errors we were seeing on production.
