### PR TITLE
Fix json content headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -418,23 +418,27 @@ def get_orgs_attendance(organization_name):
     if not organization:
         return "Organization not found", 404
 
+    attendance_response = {
+        "organization_name": organization.name,
+        "cfapi_url": organization.api_url(),
+        "total": 0,
+        "weekly": {}
+    }
+
     # Get that organization's attendance
     attendance = Attendance.query.filter_by(organization_name=organization.name).first()
 
-    weekly = {}
-    for week in attendance.weekly.keys():
-        if week in weekly.keys():
-            weekly[week] += attendance.weekly[week]
-        else:
-            weekly[week] = attendance.weekly[week]
-    attendance.weekly = weekly
+    if attendance:
+        weekly = {}
+        for week in attendance.weekly.keys():
+            if week in weekly.keys():
+                weekly[week] += attendance.weekly[week]
+            else:
+                weekly[week] = attendance.weekly[week]
+        attendance.weekly = weekly
 
-    attendance_response = {
-        "organization_name": attendance.organization_name,
-        "cfapi_url": attendance.organization_url,
-        "total": attendance.total,
-        "weekly": attendance.weekly
-    }
+        attendance_response['total'] = attendance.total
+        attendance_response['weekly'] = attendance.weekly
 
     return jsonify(attendance_response)
 

--- a/app.py
+++ b/app.py
@@ -288,7 +288,7 @@ def gather_orgs_rsvps(organization_name=None):
     orgs_events = Event.query.filter(Event.organization_name == organization.name).all()
     rsvps = build_rsvps_response(orgs_events)
 
-    return json.dumps(rsvps)
+    return jsonify(rsvps)
 
 
 @app.route("/api/organizations/<organization_name>/stories")
@@ -436,7 +436,7 @@ def get_orgs_attendance(organization_name):
         "weekly": attendance.weekly
     }
 
-    return json.dumps(attendance_response)
+    return jsonify(attendance_response)
 
 
 def find(lst, key, value):
@@ -467,7 +467,7 @@ def get_all_orgs_attendance():
         }
         response.append(attendance_response)
 
-    return json.dumps(response)
+    return jsonify(response)
 
 
 @app.route("/api/attendance")
@@ -520,7 +520,7 @@ def orgs_member_count():
         "organizations": orgs_members
     }
 
-    return json.dumps(response)
+    return jsonify(response)
 
 
 @app.route('/api/projects')
@@ -747,7 +747,7 @@ def gather_all_rsvps():
     events = Event.query.all()
     rsvps = build_rsvps_response(events)
 
-    return json.dumps(rsvps)
+    return jsonify(rsvps)
 
 
 @app.route('/api/stories')

--- a/app.py
+++ b/app.py
@@ -467,7 +467,7 @@ def get_all_orgs_attendance():
         }
         response.append(attendance_response)
 
-    return jsonify(response)
+    return jsonify(dict(organizations=response, total=len(response)))
 
 
 @app.route("/api/attendance")

--- a/test/integration/test_attendance.py
+++ b/test/integration/test_attendance.py
@@ -50,11 +50,11 @@ class TestAttendance(IntegrationTest):
         response = self.app.get('/api/organizations/attendance')
         self.assertEquals(response.status_code, 200)
         response = json.loads(response.data)
-        self.assertIsInstance(response, list)
-        self.assertTrue("organization_name" in response[0].keys())
-        self.assertTrue("cfapi_url" in response[0].keys())
-        self.assertTrue("total" in response[0].keys())
-        self.assertTrue("weekly" in response[0].keys())
+        self.assertIsInstance(response, dict)
+        self.assertTrue("organization_name" in response['organizations'][0].keys())
+        self.assertTrue("cfapi_url" in response['organizations'][0].keys())
+        self.assertTrue("total" in response['organizations'][0].keys())
+        self.assertTrue("weekly" in response['organizations'][0].keys())
 
 
     def test_org_attendance(self):


### PR DESCRIPTION
We were returning data as `text/html` from 5 routes; this fixes that and also:

- returns a non-error response from `/api/organizations/<organization_name>/attendance` when there is no attendance data available
- changes the format of what's returned from `/api/organizations/attendance` because a list isn't valid JSON

@ondrae is anything or anybody consuming the `/api/organizations/attendance` endpoint that we'd need to change or inform before we merge this PR?

Closes #279