### PR TITLE
Add org name to project search

### DIFF
--- a/migrations/versions/4b2b7cde821f_add_org_name_to_search.py
+++ b/migrations/versions/4b2b7cde821f_add_org_name_to_search.py
@@ -1,0 +1,60 @@
+""" Adds organization name to the project search tsv
+
+Revision ID: 4b2b7cde821f
+Revises: 15593ff6a15f
+Create Date: 2015-11-30 17:21:56.928359
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4b2b7cde821f'
+down_revision = '15593ff6a15f'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    droptrigger = "DROP TRIGGER IF EXISTS tsvupdate_projects_trigger ON project"
+    droptriggerfunc = "DROP FUNCTION IF EXISTS project_search_trigger()"
+    createtriggerfunc = '''
+        CREATE FUNCTION project_search_trigger() RETURNS trigger AS $$
+        begin
+          new.tsv_body :=
+             setweight(to_tsvector('pg_catalog.english', coalesce(new.status,'')), 'A') ||
+             setweight(to_tsvector('pg_catalog.english', coalesce(new.tags,'')), 'A') ||
+             setweight(to_tsvector('pg_catalog.english', coalesce(new.name,'')), 'B') ||
+             setweight(to_tsvector('pg_catalog.english', coalesce(new.description,'')), 'B') ||
+             setweight(to_tsvector('pg_catalog.english', coalesce(new.languages,'')), 'A') ||
+             setweight(to_tsvector('pg_catalog.english', coalesce(new.organization_name,'')), 'A');
+          return new;
+        end
+        $$ LANGUAGE plpgsql;
+        '''
+    createtrigger = "CREATE TRIGGER tsvupdate_projects_trigger BEFORE INSERT OR UPDATE ON project FOR EACH ROW EXECUTE PROCEDURE project_search_trigger();"
+    op.execute(droptrigger)
+    op.execute(droptriggerfunc)
+    op.execute(createtriggerfunc)
+    op.execute(createtrigger)
+
+def downgrade():
+    droptrigger = "DROP TRIGGER IF EXISTS tsvupdate_projects_trigger ON project"
+    droptriggerfunc = "DROP FUNCTION IF EXISTS project_search_trigger()"
+    createtriggerfunc = '''
+        CREATE FUNCTION project_search_trigger() RETURNS trigger AS $$
+        begin
+          new.tsv_body :=
+             setweight(to_tsvector('pg_catalog.english', coalesce(new.status,'')), 'A') ||
+             setweight(to_tsvector('pg_catalog.english', coalesce(new.tags,'')), 'A') ||
+             setweight(to_tsvector('pg_catalog.english', coalesce(new.name,'')), 'B') ||
+             setweight(to_tsvector('pg_catalog.english', coalesce(new.description,'')), 'B') ||
+             setweight(to_tsvector('pg_catalog.english', coalesce(new.languages,'')), 'A');
+          return new;
+        end
+        $$ LANGUAGE plpgsql;
+        '''
+    createtrigger = "CREATE TRIGGER tsvupdate_projects_trigger BEFORE INSERT OR UPDATE ON project FOR EACH ROW EXECUTE PROCEDURE project_search_trigger();"
+    op.execute(droptrigger)
+    op.execute(droptriggerfunc)
+    op.execute(createtriggerfunc)
+    op.execute(createtrigger)

--- a/models.py
+++ b/models.py
@@ -375,7 +375,8 @@ trig_ddl = DDL("""
          setweight(to_tsvector('pg_catalog.english', coalesce(new.tags,'')), 'A') ||
          setweight(to_tsvector('pg_catalog.english', coalesce(new.name,'')), 'B') ||
          setweight(to_tsvector('pg_catalog.english', coalesce(new.description,'')), 'B') ||
-         setweight(to_tsvector('pg_catalog.english', coalesce(new.languages,'')), 'A');
+         setweight(to_tsvector('pg_catalog.english', coalesce(new.languages,'')), 'A') ||
+         setweight(to_tsvector('pg_catalog.english', coalesce(new.organization_name,'')), 'A');
       return new;
     end
     $$ LANGUAGE plpgsql;

--- a/test/integration/test_projects.py
+++ b/test/integration/test_projects.py
@@ -421,6 +421,26 @@ class TestProjects(IntegrationTest):
         self.assertEqual(org_project_response['objects'][0]['tags'], 'food stamps, health')
 
 
+    def test_project_search_includes_org_name(self):
+        """
+        The organization name is included in the project search
+        """
+        organization = OrganizationFactory(name=u"Code for San Francisco")
+        ProjectFactory(organization_name=organization.name, name="Project One")
+        organization = OrganizationFactory(name=u"Code for America")
+        ProjectFactory(organization_name=organization.name, name="Project Two")
+        db.session.commit()
+
+        project_response = self.app.get('/api/projects?q=Code for San Francisco')
+        project_response = json.loads(project_response.data)
+        self.assertEqual(len(project_response['objects']), 1)
+        self.assertEqual(project_response['objects'][0]['name'], 'Project One')
+
+        project_response = self.app.get('/api/projects?q=Code for America')
+        project_response = json.loads(project_response.data)
+        self.assertEqual(len(project_response['objects']), 1)
+        self.assertEqual(project_response['objects'][0]['name'], 'Project Two')
+
     def test_project_query_filter(self):
         '''
         Test that project query params work as expected.


### PR DESCRIPTION
Adds the `organization_name` to the search feature for projects.

Included in this PR:
- [x] Add a test to ensure searching for an organizations name returns its projects.
- [x] Add `organization_name` to the search update trigger
- [x] Write a new migration to include it. [An example](https://github.com/codeforamerica/cfapi/blob/master/migrations/versions/4f685c062cff_improved_project_search.py).

Will close #260 when merged.
