### PR TITLE
Support searching for multiple org types at once

### DIFF
--- a/app.py
+++ b/app.py
@@ -180,7 +180,6 @@ def get_organizations(name=None):
     ''' Regular response option for organizations.
     '''
 
-    filters = request.args
     filters, querystring = get_query_params(request.args)
 
     if name:
@@ -654,7 +653,6 @@ def get_issues_by_labels(labels):
     base_query = db.session.query(Issue).join(Issue.labels)
 
     # Check for parameters
-    filters = request.args
     filters, querystring = get_query_params(request.args)
     for attr, value in filters.iteritems():
         if 'project' in attr:
@@ -718,7 +716,6 @@ def get_all_upcoming_events():
     ''' Show all upcoming events.
         Return them in chronological order.
     '''
-    filters = request.args
     filters, querystring = get_query_params(request.args)
 
     query = db.session.query(Event).filter(Event.start_time_notz >= datetime.utcnow()).order_by(Event.start_time_notz)
@@ -739,7 +736,6 @@ def get_all_past_events():
     ''' Show all past events.
         Return them in reverse chronological order.
     '''
-    filters = request.args
     filters, querystring = get_query_params(request.args)
 
     query = db.session.query(Event).filter(Event.start_time_notz <= datetime.utcnow()).order_by(desc(Event.start_time_notz))
@@ -770,7 +766,6 @@ def get_stories(id=None):
     ''' Regular response option for stories.
     '''
 
-    filters = request.args
     filters, querystring = get_query_params(request.args)
 
     if id:

--- a/app.py
+++ b/app.py
@@ -563,7 +563,7 @@ def get_projects(id=None):
             org_attr = attr.split('_')[1]
             # Support searching for multiple org_types
             if "," in value:
-                values = value.split(",")
+                values = [unicode(item) for item in value.split(",")]
                 query = query.join(Project.organization).filter(getattr(Organization, org_attr).in_(values))
             else:
                 query = query.join(Project.organization).filter(getattr(Organization, org_attr).ilike(format_ilike_term(value)))

--- a/app.py
+++ b/app.py
@@ -558,7 +558,12 @@ def get_projects(id=None):
     for attr, value in filters.iteritems():
         if 'organization' in attr:
             org_attr = attr.split('_')[1]
-            query = query.join(Project.organization).filter(getattr(Organization, org_attr).ilike('%%%s%%' % value))
+            # Support searching for multiple org_types
+            if "," in value:
+                values = value.split(",")
+                query = query.join(Project.organization).filter(getattr(Organization, org_attr).in_(values))
+            else:
+                query = query.join(Project.organization).filter(getattr(Organization, org_attr).ilike('%%%s%%' % value))
         elif 'q' in attr:
             # Returns all results if the value is empty
             if value:

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ import re
 from mimetypes import guess_type
 from os.path import join
 from math import ceil
-from urllib import urlencode
+from urllib import urlencode, unquote_plus
 
 from flask import Flask, make_response, request, jsonify, render_template
 import requests
@@ -139,7 +139,7 @@ def get_query_params(args):
     filters = {}
     for key, value in args.iteritems():
         if 'page' not in key:
-            filters[key] = value.encode('utf8')
+            filters[key] = unquote_plus(value).encode('utf8')
     return filters, urlencode(filters)
 
 def format_ilike_term(term):

--- a/app.py
+++ b/app.py
@@ -5,7 +5,6 @@
 from __future__ import division
 
 from datetime import datetime, date
-import json
 import os
 import time
 import re
@@ -21,7 +20,7 @@ from sqlalchemy import desc
 from sqlalchemy.sql.expression import func
 from sqlalchemy.orm import defer
 from dictalchemy import make_class_dictable
-from flask.ext.script import Manager, prompt_bool
+from flask.ext.script import Manager, Server, prompt_bool
 from flask.ext.migrate import Migrate, MigrateCommand
 from werkzeug.contrib.fixers import ProxyFix
 from models import initialize_database, Organization, Event, Issue, Project, Story, Label, Error, Attendance
@@ -42,7 +41,7 @@ db = initialize_database(app)
 migrate = Migrate(app, db)
 manager = Manager(app)
 manager.add_command('db', MigrateCommand)
-
+manager.add_command('runserver', Server(use_debugger=True))
 
 @manager.command
 def dropdb():

--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from datetime import datetime, date
 import json
 import os
 import time
+import re
 from mimetypes import guess_type
 from os.path import join
 from math import ceil
@@ -142,6 +143,12 @@ def get_query_params(args):
             filters[key] = value
     return filters, urlencode(filters)
 
+def format_ilike_term(term):
+    ''' Format the passed term for use in an ilike query.
+    '''
+    # strip pattern-matching metacharacters from the term
+    stripped_term = re.sub(ur'\||_|%|\*|\+|\?|\{|\}|\(|\)|\[|\]', '', term)
+    return u'%{}%'.format(stripped_term)
 
 def build_rsvps_response(events):
     ''' Arrange and organize rsvps from a list of event objects '''
@@ -196,7 +203,7 @@ def get_organizations(name=None):
             query = query.filter("organization.tsv_body @@ plainto_tsquery('%s')" % value)
             ordering = desc(func.ts_rank(Organization.tsv_body, func.plainto_tsquery('%s' % value)))
         else:
-            query = query.filter(getattr(Organization, attr).ilike('%%%s%%' % value))
+            query = query.filter(getattr(Organization, attr).ilike(format_ilike_term(value)))
 
     query = query.order_by(ordering)
     response = paged_results(query=query, include_args=dict(include_extras=True), page=int(request.args.get('page', 1)), per_page=int(request.args.get('per_page', 10)), querystring=querystring)
@@ -350,7 +357,7 @@ def get_orgs_projects(organization_name):
             else:
                 ordering_dir = 'desc'
         else:
-            query = query.filter(getattr(Project, attr).ilike('%%%s%%' % value))
+            query = query.filter(getattr(Project, attr).ilike(format_ilike_term(value)))
 
     if ordering_filter_name == 'last_updated':
         ordering_filter = last_updated_ordering_filter
@@ -389,7 +396,7 @@ def get_orgs_issues(organization_name, labels=None):
         labels = [label.strip() for label in labels.split(',')]
 
         # Create the filter for each label
-        labels = [Label.name.ilike('%{}%'.format(label)) for label in labels]
+        labels = [Label.name.ilike(format_ilike_term(label)) for label in labels]
 
         # Create the base query object by joining on Issue.labels
         query = query.join(Issue.labels)
@@ -563,7 +570,7 @@ def get_projects(id=None):
                 values = value.split(",")
                 query = query.join(Project.organization).filter(getattr(Organization, org_attr).in_(values))
             else:
-                query = query.join(Project.organization).filter(getattr(Organization, org_attr).ilike('%%%s%%' % value))
+                query = query.join(Project.organization).filter(getattr(Organization, org_attr).ilike(format_ilike_term(value)))
         elif 'q' in attr:
             # Returns all results if the value is empty
             if value:
@@ -583,7 +590,7 @@ def get_projects(id=None):
             else:
                 ordering_dir = 'desc'
         else:
-            query = query.filter(getattr(Project, attr).ilike('%%%s%%' % value))
+            query = query.filter(getattr(Project, attr).ilike(format_ilike_term(value)))
 
     if ordering_filter_name == 'last_updated':
         ordering_filter = last_updated_ordering_filter
@@ -623,12 +630,12 @@ def get_issues(id=None):
     for attr, value in filters.iteritems():
         if 'project' in attr:
             proj_attr = attr.split('_')[1]
-            query = query.join(Issue.project).filter(getattr(Project, proj_attr).ilike('%%%s%%' % value))
+            query = query.join(Issue.project).filter(getattr(Project, proj_attr).ilike(format_ilike_term(value)))
         elif 'organization' in attr:
             org_attr = attr.split('_')[1]
-            query = query.join(Issue.project).join(Project.organization).filter(getattr(Organization, org_attr).ilike('%%%s%%' % value))
+            query = query.join(Issue.project).join(Project.organization).filter(getattr(Organization, org_attr).ilike(format_ilike_term(value)))
         else:
-            query = query.filter(getattr(Issue, attr).ilike('%%%s%%' % value))
+            query = query.filter(getattr(Issue, attr).ilike(format_ilike_term(value)))
 
     response = paged_results(query=query, include_args=dict(include_project=True, include_labels=True), page=int(request.args.get('page', 1)), per_page=int(request.args.get('per_page', 10)), querystring=querystring)
     return jsonify(response)
@@ -643,7 +650,7 @@ def get_issues_by_labels(labels):
     labels = [label.strip() for label in labels.split(',')]
 
     # Create the filter for each label
-    labels = [Label.name.ilike('%%%s%%' % label) for label in labels]
+    labels = [Label.name.ilike(format_ilike_term(label)) for label in labels]
 
     # Create the base query object by joining on Issue.labels
     base_query = db.session.query(Issue).join(Issue.labels)
@@ -654,14 +661,14 @@ def get_issues_by_labels(labels):
     for attr, value in filters.iteritems():
         if 'project' in attr:
             proj_attr = attr.split('_')[1]
-            base_query = base_query.join(Issue.project).filter(getattr(Project, proj_attr).ilike('%%%s%%' % value))
+            base_query = base_query.join(Issue.project).filter(getattr(Project, proj_attr).ilike(format_ilike_term(value)))
         elif 'organization' in attr:
             org_attr = attr.split('_')[1]
-            base_query = base_query.join(Issue.project).join(Project.organization).filter(getattr(Organization, org_attr).ilike('%%%s%%' % value))
+            base_query = base_query.join(Issue.project).join(Project.organization).filter(getattr(Organization, org_attr).ilike(format_ilike_term(value)))
         else:
             try:
                 filter_attr = getattr(Issue, attr)
-                base_query = base_query.filter(filter_attr.ilike('%%%s%%' % value))
+                base_query = base_query.filter(filter_attr.ilike(format_ilike_term(value)))
             except AttributeError:
                 pass
 
@@ -700,9 +707,9 @@ def get_events(id=None):
     for attr, value in filters.iteritems():
         if 'organization' in attr:
             org_attr = attr.split('_')[1]
-            query = query.join(Event.organization).filter(getattr(Organization, org_attr).ilike('%%%s%%' % value))
+            query = query.join(Event.organization).filter(getattr(Organization, org_attr).ilike(format_ilike_term(value)))
         else:
-            query = query.filter(getattr(Event, attr).ilike('%%%s%%' % value))
+            query = query.filter(getattr(Event, attr).ilike(format_ilike_term(value)))
 
     response = paged_results(query=query, include_args=dict(include_organization=True), page=int(request.args.get('page', 1)), per_page=int(request.args.get('per_page', 25)), querystring=querystring)
     return jsonify(response)
@@ -721,9 +728,9 @@ def get_all_upcoming_events():
     for attr, value in filters.iteritems():
         if 'organization' in attr:
             org_attr = attr.split('_')[1]
-            query = query.join(Event.organization).filter(getattr(Organization, org_attr).ilike('%%%s%%' % value))
+            query = query.join(Event.organization).filter(getattr(Organization, org_attr).ilike(format_ilike_term(value)))
         else:
-            query = query.filter(getattr(Event, attr).ilike('%%%s%%' % value))
+            query = query.filter(getattr(Event, attr).ilike(format_ilike_term(value)))
 
     response = paged_results(query=query, include_args=dict(include_organization=True), page=int(request.args.get('page', 1)), per_page=int(request.args.get('per_page', 25)))
     return jsonify(response)
@@ -742,9 +749,9 @@ def get_all_past_events():
     for attr, value in filters.iteritems():
         if 'organization' in attr:
             org_attr = attr.split('_')[1]
-            query = query.join(Event.organization).filter(getattr(Organization, org_attr).ilike('%%%s%%' % value))
+            query = query.join(Event.organization).filter(getattr(Organization, org_attr).ilike(format_ilike_term(value)))
         else:
-            query = query.filter(getattr(Event, attr).ilike('%%%s%%' % value))
+            query = query.filter(getattr(Event, attr).ilike(format_ilike_term(value)))
 
     response = paged_results(query=query, include_args=dict(include_organization=True), page=int(request.args.get('page', 1)), per_page=int(request.args.get('per_page', 25)))
     return jsonify(response)
@@ -784,9 +791,9 @@ def get_stories(id=None):
     for attr, value in filters.iteritems():
         if 'organization' in attr:
             org_attr = attr.split('_')[1]
-            query = query.join(Story.organization).filter(getattr(Organization, org_attr).ilike('%%%s%%' % value))
+            query = query.join(Story.organization).filter(getattr(Organization, org_attr).ilike(format_ilike_term(value)))
         else:
-            query = query.filter(getattr(Story, attr).ilike('%%%s%%' % value))
+            query = query.filter(getattr(Story, attr).ilike(format_ilike_term(value)))
 
     response = paged_results(query=query, include_args=dict(include_organization=True), page=int(request.args.get('page', 1)), per_page=int(request.args.get('per_page', 25)), querystring=querystring)
     return jsonify(response)

--- a/models.py
+++ b/models.py
@@ -335,7 +335,7 @@ class Project(db.Model):
     def api_url(self):
         ''' API link to itself
         '''
-        return '%s://%s/api/projects/%s' % (request.scheme, request.host, str(self.id))
+        return u'{}://{}/api/projects/{}'.format(request.scheme, request.host, str(self.id))
 
     def asdict(self, include_organization=False, include_issues=True):
         ''' Return Project as a dictionary, with some properties tweaked.

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ newrelic==2.40.0.34
 psycopg2==2.5.2
 python-dateutil==2.2
 python-termstyle==0.1.10
-requests==1.2.3
+requests==2.9.0
 six==1.5.2
 SQLAlchemy==0.9.3
 Unidecode==0.4.14

--- a/test/factories.py
+++ b/test/factories.py
@@ -33,11 +33,11 @@ class ProjectFactory(SQLAlchemyModelFactory):
     description = u'This is a description'
     type = factory.LazyAttribute(lambda n: choice([u'web service', u'api', u'data standard']))
     categories = factory.LazyAttribute(lambda n: choice([u'housing', u'community engagement', u'criminal justice', u'education']))
-    tags = ['what', 'ever', '', '†≈ç®åz¥≈†']
+    tags = [u'what', u'ever', u'', u'†≈ç®åz¥≈†']
     github_details = {'repo': u'git@github.com:codeforamerica/civic-project.git'}
     organization_name = factory.LazyAttribute(lambda e: OrganizationFactory().name)
     status = u'Project status'
-    languages = ['Python', 'CSS']
+    languages = [u'Python', u'CSS']
 
 class EventFactory(SQLAlchemyModelFactory):
     FACTORY_FOR = Event

--- a/test/factories.py
+++ b/test/factories.py
@@ -38,6 +38,7 @@ class ProjectFactory(SQLAlchemyModelFactory):
     organization_name = factory.LazyAttribute(lambda e: OrganizationFactory().name)
     status = u'Project status'
     languages = [u'Python', u'CSS']
+    last_updated = factory.LazyAttribute(lambda o: datetime.utcnow())
 
 class EventFactory(SQLAlchemyModelFactory):
     FACTORY_FOR = Event

--- a/test/integration/test_attendance.py
+++ b/test/integration/test_attendance.py
@@ -8,12 +8,16 @@ from app import db, Attendance
 class TestAttendance(IntegrationTest):
 
     def test_attendance(self):
-        cfsf = OrganizationFactory(name="Code for San Francisco")
-        url = "https://www.codeforamerica.org/api/organizations/Code-for-San-Francisco"
-        cfsf_att = AttendanceFactory(organization_name="Code for San Francisco", organization_url=url)
-        oakland = OrganizationFactory(name="Open Oakland")
-        url = "https://www.codeforamerica.org/api/organizations/Open-Oakland"
-        oakland_att = AttendanceFactory(organization_name="Open Oakland", organization_url=url)
+        cfsf = OrganizationFactory(name=u"Code for San Francisco")
+        url = u"https://www.codeforamerica.org/api/organizations/Code-for-San-Francisco"
+        cfsf_att = AttendanceFactory(organization_name=u"Code for San Francisco", organization_url=url)
+        oakland = OrganizationFactory(name=u"Open Oakland")
+        url = u"https://www.codeforamerica.org/api/organizations/Open-Oakland"
+        oakland_att = AttendanceFactory(organization_name=u"Open Oakland", organization_url=url)
+        db.session.add(cfsf)
+        db.session.add(cfsf_att)
+        db.session.add(oakland)
+        db.session.add(oakland_att)
         db.session.commit()
 
         response = self.app.get('/api/attendance')
@@ -34,17 +38,16 @@ class TestAttendance(IntegrationTest):
                     weekly[week] += att.weekly[week]
                 else:
                     weekly[week] = att.weekly[week]
-        self.assertEqual(response["total"],total)
-        self.assertEqual(response["weekly"],weekly)
-
+        self.assertEqual(response["total"], total)
+        self.assertEqual(response["weekly"], weekly)
 
     def test_orgs_attendance(self):
-        OrganizationFactory(name="Code for San Francisco")
-        url = "https://www.codeforamerica.org/api/organizations/Code-for-San-Francisco"
-        AttendanceFactory(organization_name="Code for San Francisco", organization_url=url)
-        OrganizationFactory(name="Open Oakland")
-        url = "https://www.codeforamerica.org/api/organizations/Open-Oakland"
-        AttendanceFactory(organization_name="Open Oakland", organization_url=url)
+        OrganizationFactory(name=u"Code for San Francisco")
+        url = u"https://www.codeforamerica.org/api/organizations/Code-for-San-Francisco"
+        AttendanceFactory(organization_name=u"Code for San Francisco", organization_url=url)
+        OrganizationFactory(name=u"Open Oakland")
+        url = u"https://www.codeforamerica.org/api/organizations/Open-Oakland"
+        AttendanceFactory(organization_name=u"Open Oakland", organization_url=url)
         db.session.commit()
 
         response = self.app.get('/api/organizations/attendance')
@@ -56,11 +59,10 @@ class TestAttendance(IntegrationTest):
         self.assertTrue("total" in response['organizations'][0].keys())
         self.assertTrue("weekly" in response['organizations'][0].keys())
 
-
     def test_org_attendance(self):
-        OrganizationFactory(name="Code for San Francisco")
-        url = "https://www.codeforamerica.org/api/organizations/Code-for-San-Francisco"
-        AttendanceFactory(organization_name="Code for San Francisco", organization_url=url)
+        OrganizationFactory(name=u"Code for San Francisco")
+        url = u"https://www.codeforamerica.org/api/organizations/Code-for-San-Francisco"
+        AttendanceFactory(organization_name=u"Code for San Francisco", organization_url=url)
         db.session.commit()
 
         response = self.app.get('/api/organizations/Code-for-San-Francisco/attendance')
@@ -71,4 +73,3 @@ class TestAttendance(IntegrationTest):
         self.assertTrue("cfapi_url" in response.keys())
         self.assertTrue("total" in response.keys())
         self.assertTrue("weekly" in response.keys())
-

--- a/test/integration/test_projects.py
+++ b/test/integration/test_projects.py
@@ -10,9 +10,9 @@ from app import db, Issue
 class TestProjects(IntegrationTest):
 
     def test_all_projects_order(self):
-        """
+        '''
         Test that projects gets returned in order of last_updated
-        """
+        '''
         ProjectFactory(name=u'Project 1', last_updated='Mon, 01 Jan 2010 00:00:00 GMT')
         ProjectFactory(name=u'Project 2', last_updated='Tue, 01 Jan 2011 00:00:00 GMT')
         ProjectFactory(name=u'Non Github Project', last_updated='Wed, 01 Jan 2013 00:00:00', github_details=None)
@@ -311,17 +311,17 @@ class TestProjects(IntegrationTest):
             with correct ranking values
         '''
         organization = OrganizationFactory(name=u"Code for San Francisco")
-        ProjectFactory(organization_name=organization.name, status='TEST', last_updated=datetime.now() - timedelta(10000))
-        ProjectFactory(organization_name=organization.name, description='testing a new thing', last_updated=datetime.now() - timedelta(1))
-        ProjectFactory(organization_name=organization.name, tags=['test,tags,what,ever'], last_updated=datetime.now() - timedelta(100))
+        ProjectFactory(organization_name=organization.name, status=u'TEST', last_updated=datetime.now() - timedelta(10000))
+        ProjectFactory(organization_name=organization.name, description=u'testing a new thing', last_updated=datetime.now() - timedelta(1))
+        ProjectFactory(organization_name=organization.name, tags=[u'test,tags,what,ever'], last_updated=datetime.now() - timedelta(100))
         ProjectFactory(organization_name=organization.name, last_updated=datetime.now())
         db.session.commit()
         project_response = self.app.get('/api/projects?q=TEST')
         project_response = json.loads(project_response.data)
         self.assertEqual(project_response['total'], 3)
-        self.assertEqual(project_response['objects'][0]['status'], 'TEST')
-        self.assertEqual(project_response['objects'][1]['tags'], ['test,tags,what,ever'])
-        self.assertEqual(project_response['objects'][2]['description'], 'testing a new thing')
+        self.assertEqual(project_response['objects'][0]['status'], u'TEST')
+        self.assertEqual(project_response['objects'][1]['tags'], [u'test,tags,what,ever'])
+        self.assertEqual(project_response['objects'][2]['description'], u'testing a new thing')
 
     def test_project_return_only_ids(self):
         ''' Search results from the project and org/project endpoints are returned
@@ -437,9 +437,9 @@ class TestProjects(IntegrationTest):
         self.assertEqual(org_project_response['objects'][0]['name'], 'My Cool Project')
 
     def test_project_search_includes_tags(self):
-        """
+        '''
         The tags field is included in search results from the project and org/project endpoints
-        """
+        '''
         organization = OrganizationFactory(name=u"Code for San Francisco")
         ProjectFactory(organization_name=organization.name, tags=['mapping', 'philly'])
         ProjectFactory(organization_name=organization.name, tags=['food stamps', 'health'])
@@ -455,35 +455,35 @@ class TestProjects(IntegrationTest):
         self.assertEqual(org_project_response['objects'][0]['tags'], ['food stamps', 'health'])
 
     def test_project_search_includes_organization_name(self):
-        """
+        '''
         The organization name is included in the project search
-        """
+        '''
         organization = OrganizationFactory(name=u"Code for San Francisco")
-        ProjectFactory(organization_name=organization.name, name="Project One")
-        ProjectFactory(organization_name=organization.name, name="Project Two", description="America")
+        ProjectFactory(organization_name=organization.name, name=u"Project One")
+        ProjectFactory(organization_name=organization.name, name=u"Project Two", description=u"America")
 
         organization = OrganizationFactory(name=u"Code for America")
-        ProjectFactory(organization_name=organization.name, name="Project Three")
-        ProjectFactory(organization_name=organization.name, name="Project Four", tags="San Francisco")
+        ProjectFactory(organization_name=organization.name, name=u"Project Three")
+        ProjectFactory(organization_name=organization.name, name=u"Project Four", tags=u"San Francisco")
         db.session.commit()
 
         # Test that org_name matches return before project name
         project_response = self.app.get('/api/projects?q=Code+for+San+Francisco')
         project_response = json.loads(project_response.data)
         self.assertEqual(len(project_response['objects']), 3)
-        self.assertEqual(project_response['objects'][0]['name'], 'Project One')
-        self.assertEqual(project_response['objects'][1]['name'], 'Project Two')
-        self.assertEqual(project_response['objects'][2]['name'], 'Project Four')
+        self.assertEqual(project_response['objects'][0]['name'], u'Project One')
+        self.assertEqual(project_response['objects'][1]['name'], u'Project Two')
+        self.assertEqual(project_response['objects'][2]['name'], u'Project Four')
         self.assertTrue('San Francisco' in project_response['objects'][2]['tags'])
 
         # Test that org name matches return before project description
         project_response = self.app.get('/api/projects?q=Code for America')
         project_response = json.loads(project_response.data)
         self.assertEqual(len(project_response['objects']), 3)
-        self.assertEqual(project_response['objects'][0]['name'], 'Project Three')
-        self.assertEqual(project_response['objects'][1]['name'], 'Project Four')
-        self.assertEqual(project_response['objects'][2]['name'], 'Project Two')
-        self.assertEqual(project_response['objects'][2]['description'], 'America')
+        self.assertEqual(project_response['objects'][0]['name'], u'Project Three')
+        self.assertEqual(project_response['objects'][1]['name'], u'Project Four')
+        self.assertEqual(project_response['objects'][2]['name'], u'Project Two')
+        self.assertEqual(project_response['objects'][2]['description'], u'America')
 
     def test_project_query_filter(self):
         '''

--- a/test/integration/test_projects.py
+++ b/test/integration/test_projects.py
@@ -500,13 +500,13 @@ class TestProjects(IntegrationTest):
         web_project = ProjectFactory(name=u'Random Web App', type=u'web service')
         other_web_project = ProjectFactory(name=u'Random Web App 2', type=u'web service', description=u'Another')
         non_web_project = ProjectFactory(name=u'Random Other App', type=u'other service')
-        gov_project = ProjectFactory(name=u'Gov App')
-
+        gov_project = ProjectFactory(name=u'Gov App', type=u'data standard')
         web_project.organization = brigade
         non_web_project.organization = brigade_somewhere_far
         gov_project.organization = gov_org
 
         db.session.add(web_project)
+        db.session.add(other_web_project)
         db.session.add(non_web_project)
         db.session.add(gov_project)
         db.session.commit()

--- a/test/integration/test_projects.py
+++ b/test/integration/test_projects.py
@@ -489,7 +489,7 @@ class TestProjects(IntegrationTest):
         '''
         Test searching for projects from certain types of organizations.
         '''
-        brigade = OrganizationFactory(name=u'Brigade Org', type=u'Brigade')
+        brigade = OrganizationFactory(name=u'Brigade Org', type=u'Brigade, midwest')
         code_for_all = OrganizationFactory(name=u'Code for All Org', type=u'Code for All')
         gov_org = OrganizationFactory(name=u'Gov Org', type=u'Government')
 

--- a/test/integration/test_projects.py
+++ b/test/integration/test_projects.py
@@ -306,7 +306,6 @@ class TestProjects(IntegrationTest):
         self.assertEqual(len(org_project_response["objects"]), 2)
         self.assertEqual(org_project_response['objects'][0]['description'], 'ruby ruby ruby ruby ruby')
 
-
     def test_project_search_ranked_order(self):
         ''' Search results from the project and org/project endpoints are returned
             with correct ranking values
@@ -323,7 +322,6 @@ class TestProjects(IntegrationTest):
         self.assertEqual(project_response['objects'][0]['status'], 'TEST')
         self.assertEqual(project_response['objects'][1]['tags'], ['test,tags,what,ever'])
         self.assertEqual(project_response['objects'][2]['description'], 'testing a new thing')
-
 
     def test_project_return_only_ids(self):
         ''' Search results from the project and org/project endpoints are returned
@@ -438,7 +436,6 @@ class TestProjects(IntegrationTest):
         self.assertEqual(len(org_project_response['objects']), 1)
         self.assertEqual(org_project_response['objects'][0]['name'], 'My Cool Project')
 
-
     def test_project_search_includes_tags(self):
         """
         The tags field is included in search results from the project and org/project endpoints
@@ -456,7 +453,6 @@ class TestProjects(IntegrationTest):
         org_project_response = json.loads(org_project_response.data)
         self.assertEqual(len(org_project_response['objects']), 1)
         self.assertEqual(org_project_response['objects'][0]['tags'], ['food stamps', 'health'])
-
 
     def test_project_search_includes_organization_name(self):
         """
@@ -478,7 +474,7 @@ class TestProjects(IntegrationTest):
         self.assertEqual(project_response['objects'][0]['name'], 'Project One')
         self.assertEqual(project_response['objects'][1]['name'], 'Project Two')
         self.assertEqual(project_response['objects'][2]['name'], 'Project Four')
-        self.assertTrue( 'San Francisco' in project_response['objects'][2]['tags'] )
+        self.assertTrue('San Francisco' in project_response['objects'][2]['tags'])
 
         # Test that org name matches return before project description
         project_response = self.app.get('/api/projects?q=Code for America')
@@ -488,7 +484,6 @@ class TestProjects(IntegrationTest):
         self.assertEqual(project_response['objects'][1]['name'], 'Project Four')
         self.assertEqual(project_response['objects'][2]['name'], 'Project Two')
         self.assertEqual(project_response['objects'][2]['description'], 'America')
-
 
     def test_project_query_filter(self):
         '''
@@ -572,6 +567,9 @@ class TestProjects(IntegrationTest):
         issue = IssueFactory(title=u'TEST ISSUE', project_id=project.id)
         another_issue = IssueFactory(title=u'ANOTHER TEST ISSUE', project_id=project.id)
         a_third_issue = IssueFactory(title=u'A THIRD TEST ISSUE', project_id=project.id)
+        db.session.add(issue)
+        db.session.add(another_issue)
+        db.session.add(a_third_issue)
         db.session.commit()
 
         # make sure the issues are in the db

--- a/test/integration/test_projects.py
+++ b/test/integration/test_projects.py
@@ -458,16 +458,20 @@ class TestProjects(IntegrationTest):
         Test that project query params work as expected.
         '''
         brigade = OrganizationFactory(name=u'Whatever', type=u'Brigade')
-        brigade_somewhere_far = OrganizationFactory(name=u'Brigade Organization', type=u'Brigade, Code for All')
+        brigade_somewhere_far = OrganizationFactory(name=u'Brigade Organization', type=u'Code for All')
+        gov_org = OrganizationFactory(name=u'Gov Org', type=u'Government')
         web_project = ProjectFactory(name=u'Random Web App', type=u'web service')
         other_web_project = ProjectFactory(name=u'Random Web App 2', type=u'web service', description=u'Another')
         non_web_project = ProjectFactory(name=u'Random Other App', type=u'other service')
+        gov_project = ProjectFactory(name=u'Gov App')
 
         web_project.organization = brigade
         non_web_project.organization = brigade_somewhere_far
+        gov_project.organization = gov_org
 
         db.session.add(web_project)
         db.session.add(non_web_project)
+        db.session.add(gov_project)
         db.session.commit()
 
         response = self.app.get('/api/projects?type=web%20service')
@@ -492,6 +496,11 @@ class TestProjects(IntegrationTest):
         self.assertEqual(response.status_code, 200)
         response = json.loads(response.data)
         self.assertEqual(response['total'], 1)
+
+        response = self.app.get('/api/projects?organization_type=Brigade,Code+for+All')
+        self.assertEqual(response.status_code, 200)
+        response = json.loads(response.data)
+        self.assertEqual(response['total'], 3)
 
     def test_project_cascading_deletes(self):
         ''' Test that issues get deleted when their parent

--- a/test/updater/test_run_update.py
+++ b/test/updater/test_run_update.py
@@ -736,6 +736,7 @@ class RunUpdateTestCase(unittest.TestCase):
 
         philly = OrganizationFactory(name=u'Code for Philly', projects_list_url=u'http://codeforphilly.org/projects.csv')
         old_project = ProjectFactory(name=u'Philly Map of Shame', organization_name=u'Code for Philly', description=u'PHL Map of Shame is a citizen-led project to map the impact of the School Reform Commission\u2019s \u201cdoomsday budget\u201d on students and parents. We will visualize complaints filed with the Pennsylvania Department of Education.', categories=u'Education, CivicEngagement', tags=[u'philly', u'mapping'], type=None, link_url=u'http://phillymapofshame.org', code_url=None, status=u'In Progress')
+        old_project.last_updated = "2000-01-01"
         self.db.session.flush()
 
         def overwrite_response_content(url, request):
@@ -747,7 +748,7 @@ class RunUpdateTestCase(unittest.TestCase):
                 import run_update
                 projects = run_update.get_projects(philly)
                 # If the two descriptions are equal, it won't update last_updated
-                assert projects[0]['last_updated'] == None
+                self.assertEqual(projects[0]['last_updated'], "2000-01-01")
 
     def test_issue_paging(self):
         ''' test that issues are following page links '''

--- a/test/updater/test_run_update.py
+++ b/test/updater/test_run_update.py
@@ -1584,10 +1584,10 @@ class RunUpdateTestCase(unittest.TestCase):
     def test_attendance(self):
         ''' Test gathering attendance from the peopledb '''
         # Mock attendance data
-        cfsf_url = "https://www.codeforamerica.org/api/organizations/Code-for-San-Francisco"
-        cfsf_name = "Code for San Francisco"
-        oakland_url = "https://www.codeforamerica.org/api/organizations/Open-Oakland"
-        oakland_name = "Open Oakland"
+        cfsf_url = u"https://www.codeforamerica.org/api/organizations/Code-for-San-Francisco"
+        cfsf_name = u"Code for San Francisco"
+        oakland_url = u"https://www.codeforamerica.org/api/organizations/Open-Oakland"
+        oakland_name = u"Open Oakland"
         cfsf_checkin1 = datetime.datetime.strptime("2015-01-01", "%Y-%m-%d")
         cfsf_checkin2 = datetime.datetime.strptime("2015-01-08", "%Y-%m-%d")
         oakland_checkin1 = datetime.datetime.strptime("2015-01-16", "%Y-%m-%d")
@@ -1613,8 +1613,8 @@ class RunUpdateTestCase(unittest.TestCase):
                 import run_update
                 from app import Attendance
                 from test.factories import OrganizationFactory
-                cfsf = OrganizationFactory(name='Code for San Francisco')
-                oakland = OrganizationFactory(name='Open Oakland')
+                cfsf = OrganizationFactory(name=u'Code for San Francisco')
+                oakland = OrganizationFactory(name=u'Open Oakland')
 
                 cfsf_attendance = run_update.get_attendance(peopledb_cursor, cfsf_url, cfsf.name)
                 self.assertEqual(cfsf_attendance["organization_name"], cfsf_name)


### PR DESCRIPTION
On the Brigade Project Search page, we want to show Brigade and Code for All project, but not Government projects, by default. Currently the CfAPI didn't allow you to do that. This PR changes that.

We want the default results from /projects to be the same as if you searched for http://www.codeforamerica.org/brigade/projects?type=Brigade,Code+for+All. This PR will make both of those work, at least on the CfAPI side.

Hey @tmaybe I could use your review of this. I think it could also use your work for changing how we are doing string matching, to a safer way that would prevent sql injection.

