### PR TITLE
Read organizations from JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,45 +121,7 @@ We also want to add support for many more services to be included, such as event
 
 ### How to add your Brigade to the API
 
-##### Brigade Information
-The new site will be powered by this [Brigade Information](https://docs.google.com/spreadsheet/ccc?key=0ArHmv-6U1drqdGNCLWV5Q0d5YmllUzE5WGlUY3hhT2c&usp=sharing) Google Spreadsheet. This way you don't need yet another account for our Brigade site. Just keep your Brigade's info up to date and you're good. Email andrewh@codeforamerica.org if you want permission to add and edit groups.
-
-The columns are:
-* Name
-* Website
-* Events Url - Point us to where ever you schedule your events. Only Meetup.com events are working right now.
-* RSS - If you have a blog, point us to it. It's pretty smart and can find the feed on its own. To show off your Google Group discussions, use a link like `https://groups.google.com/forum/feed/code-for-san-francisco/msgs/rss.xml?num=15`
-* Projects list URL - Can either be a GitHub organization url like `https://github.com/sfbrigade` or a link to a list of project URLs, described below.
-
-
-##### Projects List
-This projects list you point us to will need the following columns:
-* `name` - filled in by GitHub if left blank
-* `description` - filled in by GitHub if left blank
-* `link_url` - filled in by GitHub if left blank
-* `code_url` - Only GitHub links work for now. Others will be added as needed later.
-* `tags` - Catch-all project tagging, terms separated by commas. "Education, digital literacy, iOS, Kansas City"
-* `status` - Whatever status names you use, e.g., "Alpha, Beta, Launched, In Progress"
-
-An example:
-```
-name, description, link_url, code_url, type, categories, tags, status
-South Bend Voices, "A redeploy of CityVoice for South Bend, IN.", http://www.southbendvoices.com/, https://github.com/codeforamerica/cityvoice,,, "community engagement, housing, mapping, ruby" "In progress"
-```
-
-That projects list URL can be any flavor of csv. The easiest way is to make a Google Spreadsheet like [my example](https://docs.google.com/spreadsheet/ccc?key=0ArHmv-6U1drqdDBzNXpSZkVzRDJUQnpOS0RJM0FDWGc&usp=sharing) and then select **File > Publish it to the web**.
-
-If you are using the new Google Spreadsheets, add `/export?format=csv` to the end.
-`https://docs.google.com/spreadsheets/d/<key>/export?format=csv`
-
-If you have the older Google Drive version change `?output=html` to `?output=csv`.
-`https://docs.google.com/spreadsheet/pub?key=<key>?output=csv`
-
-Put that in the Brigade Information sheet and you're done.
-
-The projects list URL can also be a JSON file, with a list of strings containing GitHub project URLs.
-
-Lastly, the projects list URL can be a GitHub organization URL, like http://github.com/codeforamerica.
+Submit a Pull Request with your brigade's information to the [Brigade Information repository](https://github.com/codeforamerica/brigade-information). Instructions are included in that repo's [README](https://github.com/codeforamerica/brigade-information/blob/master/README.md).
 
 ### Civic.json
 To add extra data about your projects to the CfAPI, include a `civic.json` file in the top level of your repo.

--- a/org_sources.csv
+++ b/org_sources.csv
@@ -1,1 +1,1 @@
-https://docs.google.com/spreadsheet/pub?key=0ArHmv-6U1drqdGNCLWV5Q0d5YmllUzE5WGlUY3hhT2c&output=csv
+https://raw.githubusercontent.com/codeforamerica/brigade-information/master/organizations.json

--- a/run_update.py
+++ b/run_update.py
@@ -16,6 +16,7 @@ from psycopg2 import connect, extras
 from requests import get, exceptions
 from dateutil.tz import tzoffset
 import feedparser
+import json
 
 from feeds import get_first_working_feed_link
 
@@ -188,12 +189,17 @@ def get_organizations(org_sources):
     with open(org_sources) as file:
         for org_source in file.read().splitlines():
             scheme, netloc, path, _, _, _ = urlparse(org_source)
-            if os.path.splitext(path)[1] == '.json':
+            is_json = os.path.splitext(path)[1] == '.json'
+            # if it's a local file...
+            if not scheme and not netloc:
+                if is_json:
+                    organizations.extend(get_organizations_from_local_json(org_source))
+                else:
+                    organizations.extend(get_organizations_from_local_csv(org_source))
+            elif is_json:
                 organizations.extend(get_organizations_from_json(org_source))
             elif 'docs.google.com' in org_source:
                 organizations.extend(get_organizations_from_spreadsheet(org_source))
-            elif not scheme and not netloc:
-                organizations.extend(get_organizations_from_local_file(org_source))
 
     return organizations
 
@@ -220,14 +226,21 @@ def get_organizations_from_spreadsheet(org_source):
     return decode_organizations_list(organizations)
 
 
-def get_organizations_from_local_file(org_source):
-    '''
-        Get a row for each organization from a local file.
+def get_organizations_from_local_csv(org_source):
+    ''' Get a row for each organization from a local CSV file.
         Return a list of dictionaries, one for each row past the header.
     '''
     organizations = list(DictReader(open(org_source, 'rb')))
     return decode_organizations_list(organizations)
 
+
+def get_organizations_from_local_json(org_source):
+    ''' Get a row for each organization from a local JSON file.
+        Return a list of dictionaries, one for each row past the header.
+    '''
+    with open(org_source, 'rb') as org_data:
+        organizations = json.load(org_data)
+    return organizations
 
 def decode_organizations_list(organizations):
     '''
@@ -1346,7 +1359,7 @@ def main(org_name=None, org_sources=None):
 
 parser = ArgumentParser(description='''Update database from CSV source URL.''')
 parser.add_argument('--name', dest='name', help='Single organization name to update.')
-parser.add_argument('--sources', dest='sources', help='URL of an organization sources CSV file.')
+parser.add_argument('--sources', dest='sources', help='URL of an organization sources JSON file.')
 parser.add_argument('--test', action='store_const', dest='test_sources', const=TEST_ORG_SOURCES_FILENAME, help='Use the testing list of organizations.')
 
 if __name__ == "__main__":

--- a/run_update.py
+++ b/run_update.py
@@ -188,12 +188,21 @@ def get_organizations(org_sources):
     with open(org_sources) as file:
         for org_source in file.read().splitlines():
             scheme, netloc, path, _, _, _ = urlparse(org_source)
-            if 'docs.google.com' in org_source:
+            if os.path.splitext(path)[1] == '.json':
+                organizations.extend(get_organizations_from_json(org_source))
+            elif 'docs.google.com' in org_source:
                 organizations.extend(get_organizations_from_spreadsheet(org_source))
             elif not scheme and not netloc:
                 organizations.extend(get_organizations_from_local_file(org_source))
 
     return organizations
+
+
+def get_organizations_from_json(org_source):
+    ''' Get a row for each organization from a remote JSON file.
+    '''
+    got = get(org_source)
+    return got.json()
 
 
 def get_organizations_from_spreadsheet(org_source):

--- a/test_org_sources.csv
+++ b/test_org_sources.csv
@@ -1,1 +1,1 @@
-https://docs.google.com/spreadsheet/pub?key=0ArHmv-6U1drqdEVkTUtZNVlYRE5ndERLLTFDb2RqQlE&output=csv
+https://raw.githubusercontent.com/codeforamerica/brigade-information/master/test/test_organizations.json


### PR DESCRIPTION
I created a new repo, [codeforamerica/brigade-information](https://github.com/codeforamerica/brigade-information) to hold organization information in JSON format, replacing the Google spreadsheet and its CSV output.

This PR updates the organization source URLs, prefers it to be in JSON format, updates relevant tests, and updates the README to reflect the new process.

Closes #293 
