### PR TITLE
Fixes requests/urllib3 InsecurePlatformWarnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 alembic==0.6.5
 BeautifulSoup==3.2.1
+cffi==1.4.2
 colorama==0.3.3
 coverage==3.7.1
 dictalchemy==0.1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ newrelic==2.40.0.34
 psycopg2==2.5.2
 python-dateutil==2.2
 python-termstyle==0.1.10
-requests==2.9.0
+requests[security]==2.9.0
 six==1.5.2
 SQLAlchemy==0.9.3
 Unidecode==0.4.14


### PR DESCRIPTION
I added an extra security requirement to the requests package in `requirements.txt`. This installs extra packages to support true SSL connections as detailed in [this stackoverflow comment](http://stackoverflow.com/a/29099439/958481).

I also added `cffi` to `requirements.txt`; this prompts Heroku to install `libffi` and other security libraries. If these libraries aren't installed, the extra security requirement described above fails.

Closes #295 
