### PR TITLE
Support tag-based querying of organizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-install: pip install -r requirements.txt --use-mirrors
+install: pip install -r requirements.txt
 sudo: false
 before_script:
 - psql -c 'create database civic_json_worker_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 install: pip install -r requirements.txt
 sudo: false
+services:
+  - postgresql
 before_script:
 - psql -c 'create database civic_json_worker_test;' -U postgres
 - psql -c 'create database peopledbtest;' -U postgres
@@ -11,3 +13,5 @@ script:
 notifications:
   webhooks: http://project-monitor.codeforamerica.org/projects/72d031cc-8f21-4968-8db6-ff7370f5e98b/status
   slack: cfa:IjK8dNdwBJHL0Xc9FqvROliV
+addons:
+  postgresql: "9.4"

--- a/app.py
+++ b/app.py
@@ -196,6 +196,11 @@ def get_organizations(name=None):
     # Default ordering of results
     ordering = desc(Organization.last_updated)
 
+    if 'tags[]' in filters:
+        tags = request.args.getlist('tags[]')
+        query = query.filter('organization.tags ?& :tags').params(tags=tags)
+        del filters['tags[]']
+
     for attr, value in filters.iteritems():
         if 'q' in attr:
             query = query.filter('organization.tsv_body @@ plainto_tsquery(:search_query)').params(search_query=value)

--- a/models.py
+++ b/models.py
@@ -5,6 +5,7 @@ import json
 import time
 
 from flask import request
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import Mutable
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy import types, desc
@@ -85,6 +86,7 @@ class Organization(db.Model):
     events_url = db.Column(db.Unicode())
     rss = db.Column(db.Unicode())
     projects_list_url = db.Column(db.Unicode())
+    tags = db.Column(JSONB())
     type = db.Column(db.Unicode())
     city = db.Column(db.Unicode())
     latitude = db.Column(db.Float())
@@ -100,12 +102,15 @@ class Organization(db.Model):
     # can contain events, stories, projects (these relationships are defined in the child objects)
 
     def __init__(self, name, website=None, events_url=None, members_count=None,
-                 rss=None, projects_list_url=None, type=None, city=None, latitude=None, longitude=None, last_updated=time.time()):
+                 rss=None, projects_list_url=None, type=None, city=None,
+                 latitude=None, longitude=None, last_updated=time.time(),
+                 tags=[]):
         self.name = name
         self.website = website
         self.events_url = events_url
         self.rss = rss
         self.projects_list_url = projects_list_url
+        self.tags = tags
         self.type = type
         self.city = city
         self.latitude = latitude

--- a/models.py
+++ b/models.py
@@ -92,6 +92,7 @@ class Organization(db.Model):
     latitude = db.Column(db.Float())
     longitude = db.Column(db.Float())
     last_updated = db.Column(db.Integer())
+    social_profiles = db.Column(JSONB())
     started_on = db.Column(db.Unicode())
     member_count = db.Column(db.Integer())
     keep = db.Column(db.Boolean())
@@ -104,7 +105,7 @@ class Organization(db.Model):
     def __init__(self, name, website=None, events_url=None, members_count=None,
                  rss=None, projects_list_url=None, type=None, city=None,
                  latitude=None, longitude=None, last_updated=time.time(),
-                 tags=[]):
+                 tags=[], social_profiles={}):
         self.name = name
         self.website = website
         self.events_url = events_url
@@ -117,6 +118,7 @@ class Organization(db.Model):
         self.longitude = longitude
         self.keep = True
         self.last_updated = last_updated
+        self.social_profiles = social_profiles
         self.started_on = unicode(date.today())
         self.id = safe_name(raw_name(name))
         self.members_count = members_count

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ python-dateutil==2.2
 python-termstyle==0.1.10
 requests[security]==2.9.0
 six==1.5.2
-SQLAlchemy==0.9.3
+SQLAlchemy==1.1.15
 Unidecode==0.4.14
 Werkzeug==0.9.4
 wheel==0.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,5 +32,5 @@ SQLAlchemy==1.1.15
 Unidecode==0.4.14
 Werkzeug==0.9.4
 wheel==0.24.0
-git+git://github.com/pyca/cryptography.git@d0237e6dcdbbedaa50f88b6cf821f9944b734678
+cryptography==2.1.3
 freezegun==0.3.5

--- a/templates/index.html
+++ b/templates/index.html
@@ -73,6 +73,9 @@
               <dt>per_page <i>(integer)</i></dt>
               <dd>The number of results to return per page:<br><br>
               /api/organizations?per_page=5<br><br></dd>
+              <dt>tags<i>(array of strings)</i></dt>
+              <dd>An array of tags to filter the results by. For example, to select only the Code for America Brigades:<br><br>
+              /api/organizations?tags[]=Code%20For%20America&amp;tags[]=Brigade<br><br></dd>
               <dt>Organization properties</dt>
               <dd>You can add any of the <a href="#organization-properties">Organization properties</a> as a parameter and the API will filter by organizations that have that property.</dd>
             </dl>

--- a/test/integration/test_organizations.py
+++ b/test/integration/test_organizations.py
@@ -339,8 +339,8 @@ class TestOrganizations(IntegrationTest):
         '''
         Test that organization query params work as expected.
         '''
-        OrganizationFactory(name=u'Brigade Organization', type=u'Brigade')
-        OrganizationFactory(name=u'Bayamon Organization', type=u'Brigade', city=u'Bayamon, PR')
+        OrganizationFactory(name=u'Brigade Organization', type=u'Brigade', tags=['Brigade', 'Official'])
+        OrganizationFactory(name=u'Bayamon Organization', type=u'Brigade', city=u'Bayamon, PR', tags=['Brigade'])
         OrganizationFactory(name=u'Meetup Organization', type=u'Meetup')
 
         db.session.commit()
@@ -362,6 +362,21 @@ class TestOrganizations(IntegrationTest):
         self.assertEqual(response.status_code, 200)
         response = json.loads(response.data)
         self.assertEqual(response['total'], 0)
+
+        # Test tag-based filtering:
+        response = self.app.get('/api/organizations?tags[]=Brigade')
+        self.assertEqual(response.status_code, 200)
+        response = json.loads(response.data)
+        self.assertEqual(response['total'], 2)
+        self.assertEqual(response['objects'][0]['name'], u'Brigade Organization')
+        self.assertEqual(response['objects'][1]['name'], u'Bayamon Organization')
+
+        response = self.app.get('/api/organizations?tags[]=Brigade&tags[]=Official')
+        self.assertEqual(response.status_code, 200)
+        response = json.loads(response.data)
+        self.assertEqual(response['total'], 1)
+        self.assertEqual(response['objects'][0]['name'], u'Brigade Organization')
+
 
     def test_organization_query_filter_with_unescaped_characters(self):
         ''' Test that organization query params with unescaped characters work as expected.


### PR DESCRIPTION
PR codeforamerica/brigade-information#42 added
"tags" information to the brigade-information repository. To help users
of this data, like myself, filter the list effectively, this commit adds
a tags query parameter to filter the list down.

For simplicity, it uses PostgreSQL's JSONB data type to store and query
the data.