### PR TITLE
Fetch most recent meetup events for each organization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ MarkupSafe==0.18
 mccabe==0.3.1
 mock==1.0.1
 newrelic==2.40.0.34
-psycopg2==2.5.2
+psycopg2==2.7.3.2
 pyOpenSSL==17.4.0
 python-dateutil==2.2
 python-termstyle==0.1.10

--- a/run_update.py
+++ b/run_update.py
@@ -39,7 +39,8 @@ ORG_SOURCES_FILENAME = 'org_sources.csv'
 TEST_ORG_SOURCES_FILENAME = 'test_org_sources.csv'
 
 # API URL templates
-MEETUP_API_URL = "https://api.meetup.com/2/events?status=past,upcoming&format=json&group_urlname={group_urlname}&key={key}"
+# TODO: use a Meetup client library with pagination
+MEETUP_API_URL = "https://api.meetup.com/2/events?status=past,upcoming&format=json&group_urlname={group_urlname}&key={key}&desc=true&page=200"
 MEETUP_COUNT_API_URL = "https://api.meetup.com/2/groups?group_urlname={group_urlname}&key={key}"
 GITHUB_USER_REPOS_API_URL = 'https://api.github.com/users/{username}/repos'
 GITHUB_REPOS_API_URL = 'https://api.github.com/repos{repo_path}'

--- a/templates/index.html
+++ b/templates/index.html
@@ -75,7 +75,7 @@
               /api/organizations?per_page=5<br><br></dd>
               <dt>tags<i>(array of strings)</i></dt>
               <dd>An array of tags to filter the results by. For example, to select only the Code for America Brigades:<br><br>
-              /api/organizations?tags[]=Code%20For%20America&amp;tags[]=Brigade<br><br></dd>
+              /api/organizations?tags[]=Code%20for%20America&amp;tags[]=Brigade<br><br></dd>
               <dt>Organization properties</dt>
               <dd>You can add any of the <a href="#organization-properties">Organization properties</a> as a parameter and the API will filter by organizations that have that property.</dd>
             </dl>


### PR DESCRIPTION
This updates the base URL we are using to fetch events for brigades to
ensure we're getting the latest events.

Previously the query had no pagination direction specified, so it
defaulted to ascending based on time. This means that groups with more
than the default page limit's worth of events would never have any
recent events.

I also updated the "page" argument in the URL to fetch the most recent
200 events. This is probably overkill, but since Meetup creates
recurring events for up to a year in advance, I wanted to make sure to
at least get the history of these events, if a brigade had up to 3
weekly recurring events. Later, we should just paginate through events
until we get some predetermined distance in the past (i.e. we stop
checking for updates to events one month after they happen).