### PR TITLE
Add Sentry (Raven) for error tracking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
 - psql -c '\i test/peopledbtest.pgsql' -U postgres
 script:
 - green test/ -vvv --run-coverage
-- flake8 . --exclude=migrations,test --ignore=E501,E711,E712 --exit-zero
+- flake8 . --exit-zero
 notifications:
   webhooks: http://project-monitor.codeforamerica.org/projects/72d031cc-8f21-4968-8db6-ff7370f5e98b/status
   slack: cfa:IjK8dNdwBJHL0Xc9FqvROliV

--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ from urllib import urlencode, unquote_plus
 from flask import Flask, make_response, request, jsonify, render_template
 import requests
 from flask.ext.heroku import Heroku
+from raven.contrib.flask import Sentry
 from sqlalchemy import desc, or_
 from sqlalchemy.sql.expression import func
 from sqlalchemy.orm import defer
@@ -42,6 +43,14 @@ migrate = Migrate(app, db)
 manager = Manager(app)
 manager.add_command('db', MigrateCommand)
 manager.add_command('runserver', Server(use_debugger=True))
+
+
+# Provide SENTRY_DSN environment variable to automatically report all
+# exceptions to Sentry.
+if 'SENTRY_DSN' in os.environ:
+    sentry = Sentry(dsn=os.environ['SENTRY_DSN'])
+    sentry.init_app(app)
+
 
 @manager.command
 def dropdb():

--- a/app.py
+++ b/app.py
@@ -151,12 +151,14 @@ def get_query_params(args):
             filters[key] = unquote_plus(value).encode('utf8')
     return filters, urlencode(filters)
 
+
 def format_ilike_term(term):
     ''' Format the passed term for use in an ilike query.
     '''
     # strip pattern-matching metacharacters from the term
     stripped_term = re.sub(ur'\||_|%|\*|\+|\?|\{|\}|\(|\)|\[|\]', '', term)
     return u'%{}%'.format(stripped_term)
+
 
 def build_rsvps_response(events):
     ''' Arrange and organize rsvps from a list of event objects '''

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ Werkzeug==0.9.4
 wheel==0.24.0
 cryptography==2.1.3
 freezegun==0.3.5
+raven[flask]==6.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[flake8]
+# Ignore:
+# E501 = line too long
+# E711 = comparison to None should be 'if cond is None:
+# E712 = comparison to True should be ‘if cond is True:’ or ‘if cond:’
+ignore = E501,E711,E712
+exclude = migrations,test


### PR DESCRIPTION
Previously, we did not have error tracking, except what was provided by
Newrelic. Unfortunately, newrelic's error offering is built more around
aggregate error rates rather than actually recording the instances of a
single error. It is hard to drill down into.

Sentry is the best-in-class error tracking/notification service. Let's
enable it for this app.