### PR TITLE
Handle empty body from Meetup API response

### DIFF
--- a/run_update.py
+++ b/run_update.py
@@ -180,10 +180,13 @@ def get_meetup_count(organization, identifier):
     got = get(meetup_url)
     members = None
     if got and got.status_code // 100 == 2:
-        response = got.json()
-        if response:
-            if response["results"]:
-                members = response["results"][0]["members"]
+        try:
+            response = got.json()
+            if response:
+                if response["results"]:
+                    members = response["results"][0]["members"]
+        except ValueError:  # meetup API returned non-JSON response
+            return None
 
     return members
 

--- a/test/updater/test_run_update.py
+++ b/test/updater/test_run_update.py
@@ -1534,6 +1534,21 @@ class RunUpdateTestCase(unittest.TestCase):
 
         self.assertEqual(org.member_count, 100)
 
+
+    def test_meetup_count_with_empty_response(self):
+        from test.factories import OrganizationFactory
+        org = OrganizationFactory(name="TEST ORG")
+        response = {
+            "status_code": 200,
+            "content": "application/json;charset=utf-8"
+        }
+        with HTTMock(lambda _url, _request: response):
+            import run_update
+            org.member_count = run_update.get_meetup_count(organization=org, identifier="TEST-MEETUP")
+
+        self.assertEqual(org.member_count, None)
+
+
     def test_languages(self):
         ''' Test pulling languages from Github '''
         from app import Project


### PR DESCRIPTION
The Meetup API occasionally returns an empty response for a valid request that should return JSON. Since an empty string cannot be parsed as valid JSON, this causes an error and crashes the updating process.

I opened a support ticket about this a month ago but they don't seem to have made
any progress figuring this out.

It is very easy to reproduce by looking at the response size:

```bash
while :; do
  curl -s https://api.meetup.com/2/groups\?group_urlname\=Code-for-Greenville\&key\=$MEETUP_KEY | wc -c;
done
```
which returns for me:
```
       0
    3120
    3120
    3120
    3120
    3120
    3120
    3120
    3120
    3120
    3120
    3120
    3120
    3120
    3120
    3120
    3120
    3120
    3120
       0
    3120
    3120
    3120
    3120
    3120
    3120
    3120
    3120
    3120
    3120
    3120
    3120
    3120
    3120
       0
    3120
    3120
```

If this method returns None, the calling method will not overwrite any
value that exists in the column. So, over time, we will get accurate
membership information still, even if not for a specific run.

Regression test included!