### PR TITLE
Add location to events

### DIFF
--- a/migrations/versions/a5abdf9487c_add_venue_to_event.py
+++ b/migrations/versions/a5abdf9487c_add_venue_to_event.py
@@ -1,0 +1,25 @@
+from alembic import op
+import sqlalchemy as sa
+
+
+"""Add Venue To Event
+
+Revision ID: a5abdf9487c
+Revises: 578ce9f8d1
+Create Date: 2018-01-12 16:43:53.741499
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'a5abdf9487c'
+down_revision = '578ce9f8d1'
+
+
+def upgrade():
+    op.add_column('event', sa.Column('lat', sa.types.DECIMAL(20, 17)))
+    op.add_column('event', sa.Column('lon', sa.types.DECIMAL(20, 17)))
+
+
+def downgrade():
+    op.drop_column('event', 'lat')
+    op.drop_column('event', 'lon')

--- a/models.py
+++ b/models.py
@@ -502,6 +502,8 @@ class Event(db.Model):
     description = db.Column(db.Unicode())
     event_url = db.Column(db.Unicode())
     location = db.Column(db.Unicode())
+    lat = db.Column(db.DECIMAL(20, 17))
+    lon = db.Column(db.DECIMAL(20, 17))
     created_at = db.Column(db.Unicode())
     start_time_notz = db.Column(db.DateTime(False))
     end_time_notz = db.Column(db.DateTime(False))
@@ -515,10 +517,13 @@ class Event(db.Model):
     organization_name = db.Column(db.Unicode(), db.ForeignKey('organization.name', ondelete='CASCADE'), nullable=False)
 
     def __init__(self, name, event_url, start_time_notz, created_at, utc_offset,
-                 organization_name, location=None, end_time_notz=None, description=None, rsvps=None):
+                 organization_name, location=None, end_time_notz=None, description=None,
+                 rsvps=None, lat=None, lon=None):
         self.name = name
         self.description = description
         self.location = location
+        self.lat = lat
+        self.lon = lon
         self.event_url = event_url
         self.start_time_notz = start_time_notz
         self.utc_offset = utc_offset

--- a/run_update.py
+++ b/run_update.py
@@ -130,7 +130,7 @@ def format_location(venue):
     if 'address_2' in venue and venue['address_2'] != '':
         address = address + ', ' + venue['address_2']
 
-    return u'{name}, {address}'.format(name=venue['name'], address=address)
+    return u'{name}\n{address}'.format(name=venue['name'], address=address)
 
 
 def get_meetup_events(organization, group_urlname):

--- a/run_update.py
+++ b/run_update.py
@@ -155,19 +155,20 @@ def get_meetup_events(organization, group_urlname):
         try:
             results = got.json()['results']
             for event in results:
-                event = dict(organization_name=organization.name,
-                             name=event['name'],
-                             event_url=event['event_url'],
-                             start_time_notz=format_date(event['time'], event['utc_offset']),
-                             created_at=format_date(event['created'], event['utc_offset']),
-                             utc_offset=event['utc_offset'] / 1000.0,
-                             rsvps=event['yes_rsvp_count'])
+                eventdict = dict(
+                    organization_name=organization.name,
+                    name=event['name'],
+                    event_url=event['event_url'],
+                    start_time_notz=format_date(event['time'], event['utc_offset']),
+                    created_at=format_date(event['created'], event['utc_offset']),
+                    utc_offset=event['utc_offset'] / 1000.0,
+                    rsvps=event['yes_rsvp_count'])
 
                 # Some events don't have locations.
                 if 'venue' in event:
-                    event['location'] = format_location(event['venue'])
+                    eventdict['location'] = format_location(event['venue'])
 
-                events.append(event)
+                events.append(eventdict)
             return events
         except (TypeError, ValueError):
             return events

--- a/run_update.py
+++ b/run_update.py
@@ -167,6 +167,8 @@ def get_meetup_events(organization, group_urlname):
                 # Some events don't have locations.
                 if 'venue' in event:
                     eventdict['location'] = format_location(event['venue'])
+                    eventdict['lat'] = event['venue']['lat']
+                    eventdict['lon'] = event['venue']['lon']
 
                 events.append(eventdict)
             return events

--- a/run_update.py
+++ b/run_update.py
@@ -130,10 +130,7 @@ def format_location(venue):
     if 'address_2' in venue and venue['address_2'] != '':
         address = address + ', ' + venue['address_2']
 
-    if 'state' in venue:
-        return u'{address}, {city}, {state}, {country}'.format(address=address, city=venue['city'], state=venue['state'], country=venue['country'])
-    else:
-        return u'{address}, {city}, {country}'.format(address=address, city=venue['city'], country=venue['country'])
+    return u'{name}, {address}'.format(name=venue['name'], address=address)
 
 
 def get_meetup_events(organization, group_urlname):

--- a/run_update.py
+++ b/run_update.py
@@ -180,10 +180,13 @@ def get_meetup_count(organization, identifier):
     got = get(meetup_url)
     members = None
     if got and got.status_code // 100 == 2:
-        response = got.json()
-        if response:
-            if response["results"]:
-                members = response["results"][0]["members"]
+        try:
+            response = got.json()
+            if response:
+                if response["results"]:
+                    members = response["results"][0]["members"]
+        except ValueError:  # meetup API returned non-JSON response
+            return None
 
     return members
 

--- a/test/updater/test_run_update.py
+++ b/test/updater/test_run_update.py
@@ -1534,6 +1534,21 @@ class RunUpdateTestCase(unittest.TestCase):
 
         self.assertEqual(org.member_count, 100)
 
+
+    def test_meetup_count_with_empty_response(self):
+        from test.factories import OrganizationFactory
+        org = OrganizationFactory(name="TEST ORG")
+        response = {
+            "status_code": 200,
+            "content": "application/json;charset=utf-8"
+        }
+        with HTTMock(lambda _url, _request: response):
+            import run_update
+            org.member_count = run_update.get_meetup_count(organization=org, identifier="TEST-MEETUP")
+
+        self.assertEqual(org.member_count, None)
+
+
     def test_languages(self):
         ''' Test pulling languages from Github '''
         from app import Project

--- a/test/updater/test_run_update.py
+++ b/test/updater/test_run_update.py
@@ -1082,6 +1082,7 @@ class RunUpdateTestCase(unittest.TestCase):
             self.assertEqual(len(check_events[organization.name]), len(db_events[organization.name]))
             for event_dict in check_events[organization.name]:
                 event = self.db.session.query(Event).filter(Event.event_url == event_dict['event_url'], Event.organization_name == event_dict['organization_name']).first()
+                self.assertIsNotNone(event.location)
                 self.assertIsNotNone(event)
                 self.assertTrue(event.keep)
 

--- a/test/updater/test_run_update.py
+++ b/test/updater/test_run_update.py
@@ -1082,8 +1082,10 @@ class RunUpdateTestCase(unittest.TestCase):
             self.assertEqual(len(check_events[organization.name]), len(db_events[organization.name]))
             for event_dict in check_events[organization.name]:
                 event = self.db.session.query(Event).filter(Event.event_url == event_dict['event_url'], Event.organization_name == event_dict['organization_name']).first()
-                self.assertIsNotNone(event.location)
                 self.assertIsNotNone(event)
+                self.assertIsNotNone(event.location)
+                self.assertIsNotNone(event.lat)
+                self.assertIsNotNone(event.lon)
                 self.assertTrue(event.keep)
 
             # get the matching STORIES for this organization from the database


### PR DESCRIPTION
This does two things related to better surfacing event location information via the CfAPI -- fixing a bug which prevented the "location" field from ever being populated, and also adding the latitude/longitude for easier mapmaking on the client side. (Read commit messages for more detail.)