### PR TITLE
Install simplejson for JSON serialization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ wheel==0.24.0
 cryptography==2.1.3
 freezegun==0.3.5
 raven[flask]==6.4.0
+simplejson==3.13.2

--- a/test/factories.py
+++ b/test/factories.py
@@ -56,6 +56,8 @@ class EventFactory(SQLAlchemyModelFactory):
     utc_offset = -28800
     created_at = factory.LazyAttribute(lambda o: o.now)
     organization_name = factory.LazyAttribute(lambda e: OrganizationFactory().name)
+    lat = 37.7749
+    lon = -122.4194
 
     rsvps = 1234
 


### PR DESCRIPTION
If simplejson is installed, Flask will autodetect it and use it for JSON
serialization. This is necessary because the lat/lon are returned from
the database as decimal objects, which are not able to be serialized by
the stdlib JSON serializer. I guess these are things you learn as you
get better at python. If I had to do it over again, I'd make the lat/lon
fields floats instead, which seems to Just Work™.