### PR TITLE
Update "upcoming_events" to return events that haven't ended yet

### DIFF
--- a/app.py
+++ b/app.py
@@ -278,7 +278,7 @@ def get_upcoming_events(organization_name):
     if not organization:
         return "Organization not found", 404
     # Get upcoming event objects
-    query = Event.query.filter(Event.organization_name == organization.name, Event.start_time_notz >= datetime.utcnow())
+    query = Event.query.filter(Event.organization_name == organization.name, Event.end_time_notz >= datetime.utcnow())
     response = paged_results(query=query, include_args=dict(include_organization=True), page=int(request.args.get('page', 1)), per_page=int(request.args.get('per_page', 25)))
     return jsonify(response)
 
@@ -293,8 +293,8 @@ def get_past_events(organization_name):
     if not organization:
         return "Organization not found", 404
     # Get past event objects
-    query = Event.query.filter(Event.organization_name == organization.name, Event.start_time_notz < datetime.utcnow()).\
-        order_by(desc(Event.start_time_notz))
+    query = Event.query.filter(Event.organization_name == organization.name, Event.end_time_notz < datetime.utcnow()).\
+        order_by(desc(Event.end_time_notz))
     response = paged_results(query=query, include_args=dict(include_organization=True), page=int(request.args.get('page', 1)), per_page=int(request.args.get('per_page', 25)))
     return jsonify(response)
 
@@ -751,7 +751,7 @@ def get_all_upcoming_events():
     '''
     filters, querystring = get_query_params(request.args)
 
-    query = db.session.query(Event).filter(Event.start_time_notz >= datetime.utcnow()).order_by(Event.start_time_notz)
+    query = db.session.query(Event).filter(Event.end_time_notz >= datetime.utcnow()).order_by(Event.end_time_notz)
 
     for attr, value in filters.iteritems():
         if 'organization' in attr:
@@ -771,7 +771,7 @@ def get_all_past_events():
     '''
     filters, querystring = get_query_params(request.args)
 
-    query = db.session.query(Event).filter(Event.start_time_notz <= datetime.utcnow()).order_by(desc(Event.start_time_notz))
+    query = db.session.query(Event).filter(Event.end_time_notz <= datetime.utcnow()).order_by(desc(Event.end_time_notz))
 
     for attr, value in filters.iteritems():
         if 'organization' in attr:

--- a/templates/index.html
+++ b/templates/index.html
@@ -524,7 +524,7 @@
             <p>
                 /api/events <br>
                 /api/events/upcoming_events <br/>
-								/api/events/past_events <br/>
+                /api/events/past_events <br/>
                 /api/organizations/{organization id}/events <br>
                 /api/organizations/{organization id}/upcoming_events <br>
                 /api/organizations/{organization id}/past_events
@@ -550,9 +550,9 @@
             </dl>
             <h4>Event filters</h4>
             <dt>upcoming_events</dt>
-            <dd>Only returns events happening in the future.</dd>
+            <dd>Only returns events happening presently or in the future.</dd>
             <dt>past_events</dt>
-            <dd>Only returns events that have already happened.</dd>
+            <dd>Only returns events that have already ended.</dd>
         </div>
         <div class="layout-minim">
             <h4>Sample Request</h4>

--- a/test/factories.py
+++ b/test/factories.py
@@ -52,7 +52,7 @@ class EventFactory(SQLAlchemyModelFactory):
 
     now = factory.LazyAttribute(lambda o: datetime.utcnow())
     start_time_notz = factory.LazyAttribute(lambda o: o.now - timedelta(hours=10))
-    end_time_notz = factory.LazyAttribute(lambda o: o.now - timedelta(hours=12))
+    end_time_notz = factory.LazyAttribute(lambda o: o.start_time_notz + timedelta(hours=3))
     utc_offset = -28800
     created_at = factory.LazyAttribute(lambda o: o.now)
     organization_name = factory.LazyAttribute(lambda e: OrganizationFactory().name)


### PR DESCRIPTION
This updates the notion of "upcoming" and "past" event to return events
based on their _end_ time instead of their _start_ time.

We got feedback from users that they were expecting to be able to find
the meetup they were current at (or late to) on the Brigade profile
page. To quickly meet this user need, we can just update the end time. I
assume that we are the primary user of this API and thus provides no
backwards compatibility. (Happy to add an option to this endpoint to
restore the old behavior if anyone notices this change.)