### PR TITLE
Fix Orgs to return events that end in the next `utc_offset` seconds

### DIFF
--- a/test/factories.py
+++ b/test/factories.py
@@ -53,13 +53,14 @@ class EventFactory(SQLAlchemyModelFactory):
     now = factory.LazyAttribute(lambda o: datetime.utcnow())
     start_time_notz = factory.LazyAttribute(lambda o: o.now - timedelta(hours=10))
     end_time_notz = factory.LazyAttribute(lambda o: o.start_time_notz + timedelta(hours=3))
-    utc_offset = -28800
+    utc_offset = -28800  # 8 hours
     created_at = factory.LazyAttribute(lambda o: o.now)
     organization_name = factory.LazyAttribute(lambda e: OrganizationFactory().name)
     lat = 37.7749
     lon = -122.4194
 
     rsvps = 1234
+
 
 class StoryFactory(SQLAlchemyModelFactory):
     FACTORY_FOR = Story

--- a/test/integration/test_organizations.py
+++ b/test/integration/test_organizations.py
@@ -54,18 +54,20 @@ class TestOrganizations(IntegrationTest):
 
     def test_current_events(self):
         """
-        The three soonest upcoming events should be returned.
+        The two soonest upcoming events should be returned.
         If there are no events in the future, no events will be returned
         """
         # Assuming today is Christmas...
         organization = OrganizationFactory(name=u'Collective of Ericas')
         db.session.flush()
 
-        # Create multiple events, some in the future, one in the past
-        EventFactory(organization_name=organization.name, name=u'Christmas Eve', start_time_notz=datetime.now() - timedelta(1))
-        EventFactory(organization_name=organization.name, name=u'New Years', start_time_notz=datetime.now() + timedelta(7))
-        EventFactory(organization_name=organization.name, name=u'MLK Day', start_time_notz=datetime.now() + timedelta(25))
-        EventFactory(organization_name=organization.name, name=u'Cesar Chavez Day', start_time_notz=datetime.now() + timedelta(37))
+        now = datetime.now()
+
+        # Create multiple events, some in the very near future, one in the very recent past
+        EventFactory(organization_name=organization.name, name=u'Christmas Eve', start_time_notz=now - timedelta(hours=3), end_time_notz=now - timedelta(seconds=1))
+        EventFactory(organization_name=organization.name, name=u'New Years', start_time_notz=datetime.now() + timedelta(seconds=1))
+        EventFactory(organization_name=organization.name, name=u'MLK Day', start_time_notz=datetime.now() + timedelta(days=7))
+        EventFactory(organization_name=organization.name, name=u'Cesar Chavez Day', start_time_notz=datetime.now() + timedelta(days=30))
         db.session.commit()
 
         response = self.app.get('/api/organizations/Collective%20of%20Ericas')

--- a/test/integration/test_organizations.py
+++ b/test/integration/test_organizations.py
@@ -61,13 +61,26 @@ class TestOrganizations(IntegrationTest):
         organization = OrganizationFactory(name=u'Collective of Ericas')
         db.session.flush()
 
-        now = datetime.now()
+        event_utc_offset = EventFactory.attributes()['utc_offset']
+        now = datetime.utcnow()
+        now_notz = now + timedelta(seconds=event_utc_offset)
 
         # Create multiple events, some in the very near future, one in the very recent past
-        EventFactory(organization_name=organization.name, name=u'Christmas Eve', start_time_notz=now - timedelta(hours=3), end_time_notz=now - timedelta(seconds=1))
-        EventFactory(organization_name=organization.name, name=u'New Years', start_time_notz=datetime.now() + timedelta(seconds=1))
-        EventFactory(organization_name=organization.name, name=u'MLK Day', start_time_notz=datetime.now() + timedelta(days=7))
-        EventFactory(organization_name=organization.name, name=u'Cesar Chavez Day', start_time_notz=datetime.now() + timedelta(days=30))
+        EventFactory(organization_name=organization.name,
+                     name=u'Christmas Eve',
+                     start_time_notz=now_notz - timedelta(hours=3),
+                     end_time_notz=now_notz - timedelta(seconds=1))
+        EventFactory(organization_name=organization.name,
+                     name=u'New Years',
+                     start_time_notz=now_notz - timedelta(hours=2),
+                     end_time_notz=now_notz + timedelta(seconds=1))
+        EventFactory(organization_name=organization.name,
+                     name=u'MLK Day',
+                     start_time_notz=now_notz + timedelta(days=7))
+        EventFactory(organization_name=organization.name,
+                     name=u'Cesar Chavez Day',
+                     start_time_notz=now_notz + timedelta(days=30))
+
         db.session.commit()
 
         response = self.app.get('/api/organizations/Collective%20of%20Ericas')


### PR DESCRIPTION
There was a bug where since we convert the event's start and end date
into local time for storage in the `start_time_notz` and `end_time_notz`
fields, when querying for them we were using the UTC date and time.

For example, assuming an event is scheduled for:

2018-02-07 18:30:00 PST / 2018-02-08 02:30:00 UTC

Then `start_time_notz` will be the timestamp 2018-02-07 18:30:00.
However, when filtering for "current" events, we looked for events
greater to or equal to the *UTC* time, so effectively the event would
only be returned until 2018-02-07 18:29:59 UTC (2018-02-07 10:29:59
PST).

To guard against regressions, I've adjusted the test of this data to be
much more precise. (I verified that it failed before the fix.)

This also converts the logic to use the event's end time instead, to
match the logic on the `/organizations/<name>/upcoming_events` endpoint.