### PR TITLE
Tolerate new keys in issues' `label` dicts

### DIFF
--- a/models.py
+++ b/models.py
@@ -482,11 +482,11 @@ class Label(db.Model):
     issue = db.relationship('Issue', single_parent=True, cascade='all, delete-orphan', backref=backref("labels", cascade="save-update, delete"))
     issue_id = db.Column(db.Integer, db.ForeignKey('issue.id', ondelete='CASCADE'), nullable=False, index=True)
 
-    def __init__(self, name, color, url, issue_id=None):
-        self.name = name
-        self.color = color
-        self.url = url
-        self.issue_id = issue_id
+    def __init__(self, **kwargs):
+        self.name = kwargs['name']
+        self.color = kwargs['color']
+        self.url = kwargs['url']
+        self.issue_id = kwargs.get('issue_id')
 
     def asdict(self):
         '''

--- a/test/integration/test_organizations.py
+++ b/test/integration/test_organizations.py
@@ -392,7 +392,6 @@ class TestOrganizations(IntegrationTest):
         self.assertEqual(response['total'], 1)
         self.assertEqual(response['objects'][0]['name'], u'Brigade Organization')
 
-
     def test_organization_query_filter_with_unescaped_characters(self):
         ''' Test that organization query params with unescaped characters work as expected.
         '''

--- a/test/updater/test_run_update.py
+++ b/test/updater/test_run_update.py
@@ -147,7 +147,7 @@ class RunUpdateTestCase(unittest.TestCase):
         elif url.geturl() == 'https://api.github.com/repos/codeforamerica/cityvoice/issues' or url.geturl() == 'https://api.github.com/repos/codeforamerica/bizfriendly-web/issues':
             # build issues dynamically based on results_state value
             issue_lines = ['''{"html_url": "https://github.com/codeforamerica/cityvoice/issue/210","title": "Important cityvoice issue", "labels": [ xxx ],"created_at": "2015-09-16T05:45:20Z", "updated_at": "2015-10-22T17:26:02Z", "body" : "WHATEVER"}''', '''{"html_url": "https://github.com/codeforamerica/cityvoice/issue/211","title": "More important cityvoice issue", "labels": [ xxx ], "created_at" : "2015-10-26T01:13:03Z", "updated_at" : "2015-10-26T18:06:54Z", "body" : "WHATEVER"}''']
-            label_lines = ['''{ "color" : "84b6eb", "name" : "enhancement", "url": "https://api.github.com/repos/codeforamerica/cityvoice/labels/enhancement"}''', '''{ "color" : "84b6eb", "name" : "question", "url": "https://api.github.com/repos/codeforamerica/cityvoice/labels/question"}''']
+            label_lines = ['''{ "color" : "84b6eb", "name" : "enhancement", "url": "https://api.github.com/repos/codeforamerica/cityvoice/labels/enhancement", "node_id": "AAAAAA="}''', '''{ "color" : "84b6eb", "name" : "question", "url": "https://api.github.com/repos/codeforamerica/cityvoice/labels/question", "node_id": "BBBBBBB="}''']
             issue_lines_before = [sub('xxx', ','.join(label_lines[0:2]), issue_lines[0]), sub('xxx', ','.join(label_lines[0:2]), issue_lines[1])]
             issue_lines_after = [sub('xxx', ','.join(label_lines[0:1]), issue_lines[0])]
             response_etag = {'ETag': '8456bc53d4cf6b78779ded3408886f82'}


### PR DESCRIPTION
At some point, Github added a `node_id` key in the `label` dict. This is
totally fair, it should be a backwards compatible change. However, since
we passed in the raw API response as kwargs to the Label model, this
resulted in an error.

In order to better handle this, I've updated the method signature of the
Label constructor to take an arbitrary kwargs hash and pick out the
values that are necessary.

Also, I updated the test data to prevent regressions.

Fixes #333.