### PR TITLE
Install libffi-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,7 @@ notifications:
   webhooks: http://project-monitor.codeforamerica.org/projects/72d031cc-8f21-4968-8db6-ff7370f5e98b/status
   slack: cfa:IjK8dNdwBJHL0Xc9FqvROliV
 addons:
+  apt:
+    packages:
+      - libffi-dev
   postgresql: "9.4"


### PR DESCRIPTION
We're getting a build error:

```
gcc -pthread -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DUSE__THREAD -I/usr/include/ffi -I/usr/include/libffi -I/app/.heroku/python/include/python2.7 -c c/_cffi_backend.c -o build/temp.linux-x86_64-2.7/c/_cffi_backend.o
c/_cffi_backend.c:13:17: fatal error: ffi.h: No such file or directory
                ^
compilation terminated.
error: command 'gcc' failed with exit status 1
```

Googling The Error Message says that we need to install libffi-dev to
fix this.