### PR TITLE
Handle events without a venue address

### DIFF
--- a/run_update.py
+++ b/run_update.py
@@ -128,7 +128,11 @@ def format_date(time_in_milliseconds, utc_offset_msec):
 
 
 def format_location(venue):
+    if 'address_1' not in venue:
+        return venue['name']
+
     address = venue['address_1']
+
     if 'address_2' in venue and venue['address_2'] != '':
         address = address + ', ' + venue['address_2']
 


### PR DESCRIPTION
Some events (e.g. Meetup Event id #256911740) have a venue specified
with no address. Let's handle that by just returning the location's
name.